### PR TITLE
refactor: abstract API routes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3,3 +3,17 @@
 We conform to [JSON:API](https://jsonapi.org/) spec for structuring our API routes.
 
 You can view the OpenAPI explorer at http://localhost:4300/explorer or https://gloss-translation-api.vercel.app/explorer.
+
+## Defining routes
+
+Routes are defined as [nextjs API routes](https://nextjs.org/docs/api-routes/introduction). We've built a wrapper to make routes easier to build and more typesafe.
+
+Here are a couple things to keep in mind when building a route.
+
+1. Define `RequestBody` and `ResponseBody` types in the `api-types` package. These types are used to coordinate the contract between the api and clients. If the data that the api provides changes, the frontend type checker will catch that if we don't refactor the client as well.
+2. Use the `createRoute` helper and define the `Params` type parameter with the dynamic route params from the nextjs route handler file name. This will type `req.query` to include url path parameters.
+3. Use `get`, `post`, `patch`, and/or `delete` with the `RequestBody` and `ResponseBody` type parameters to define handlers for each method. Any methods that you don't define will return `405 Unspported Method` by default.
+4. If the request has a body, then define a `zod` schema to match the `RequestBody` type. This will ensure that when the `handler` is called the body data is typed to the `RequestBody` type. This schema should not have buisness logic in it, it should just validate against the `RequestBody` type. Schema violations will return `409 Conflict` or `422 Unprocessable Content` depending on the issue.
+5. Implement the api route in the `handler` function and use the `res` argument to return the appropriate response.
+6. In most cases, you do not need to handle errors from `prisma`. The route handler will return the appropriate errors for you.
+7. Add a method to the `api-client` package to type the request and response for the client.

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,4 +16,5 @@ Here are a couple things to keep in mind when building a route.
 4. If the request has a body, then define a `zod` schema to match the `RequestBody` type. This will ensure that when the `handler` is called the body data is typed to the `RequestBody` type. This schema should not have buisness logic in it, it should just validate against the `RequestBody` type. Schema violations will return `409 Conflict` or `422 Unprocessable Content` depending on the issue.
 5. Implement the api route in the `handler` function and use the `res` argument to return the appropriate response.
 6. In most cases, you do not need to handle errors from `prisma`. The route handler will return the appropriate errors for you.
-7. Add a method to the `api-client` package to type the request and response for the client.
+7. Throw errors that extend the `BaseError` class rather than returning responses directly. This simplifies generating the correct HTTP response for errors.
+8. Add a method to the `api-client` package to type the request and response for the client.

--- a/packages/api-types/src/index.ts
+++ b/packages/api-types/src/index.ts
@@ -1,9 +1,9 @@
 export * from './language';
 
-export interface Error {
+export interface ErrorDetail {
   code: string;
 }
 
 export interface ErrorResponse {
-  errors: Error[];
+  errors: ErrorDetail[];
 }

--- a/packages/api/Route.ts
+++ b/packages/api/Route.ts
@@ -4,14 +4,25 @@ import { ZodSchema } from 'zod';
 import { Prisma } from './prisma/client';
 
 export interface ResponseHelper<Body> {
-  ok(data: Body): void;
+  /** Returns 200 or 204 dependening on whether there is a response body to send. */
+  ok(data?: Body): void;
+  /** Returns 201 created with the contents of the new resource. */
   created(data: Body): void;
+  /** Returns 404 with a list of errors. By default it will have a single error with code NotFound. */
   notFound(errors?: Error[]): void;
+  /** Returns 409 with a list of errors. */
   conflict(errors: Error[]): void;
+  /** Returns 422 with a list of errors. */
   invalid(errors: Error[]): void;
 }
 
 export type RouteDefinition<Params, RequestBody, ResponseBody> = {
+  /**
+   * Defines the implementation of the route.
+   * When this is called, `req.body` will have been parsed and should match the `RequestBody` type.
+   * @param req The nextjs request object with typed query and body.
+   * @param res The response helper wrapper around the nextjs response object.
+   */
   handler(
     req: Omit<NextApiRequest, 'query' | 'body'> & {
       query: Params;
@@ -23,24 +34,62 @@ export type RouteDefinition<Params, RequestBody, ResponseBody> = {
   ? // eslint-disable-next-line @typescript-eslint/ban-types
     {}
   : {
+      /**
+       * The `zod` schema used to parse the request body.
+       * This schema should produce an object that matches the `RequestType`.
+       * If `RequestBody` is `void` then a schema is not required.
+       */
       schema:
         | ZodSchema<RequestBody>
         | ((req: NextApiRequest & { query: Params }) => ZodSchema<RequestBody>);
     });
 
 export interface RouteBuilder<Params> {
+  /**
+   * Creates a nextjs API route handler.
+   * This will compile the handlers for each method into a single handler.
+   * It also handles 405 responses for unsupported methods.
+   */
   build(): NextApiHandler;
+  /**
+   * Creates a GET route handler
+   * @template RequestBody The type of the HTTP request body. This should be validated by the `schema`.
+   * @template ResponseBody The type of the HTTP response body. This route should return a value that matches this type.
+   */
   get<RequestBody, ResponseBody>(
     definition: RouteDefinition<Params, RequestBody, ResponseBody>
   ): RouteBuilder<Params>;
+  /**
+   * Creates a PATCH route handler
+   * @template RequestBody The type of the HTTP request body. This should be validated by the `schema`.
+   * @template ResponseBody The type of the HTTP response body. This route should return a value that matches this type.
+   */
   patch<RequestBody, ResponseBody>(
     definition: RouteDefinition<Params, RequestBody, ResponseBody>
   ): RouteBuilder<Params>;
+  /**
+   * Creates a POST route handler
+   * @template RequestBody The type of the HTTP request body. This should be validated by the `schema`.
+   * @template ResponseBody The type of the HTTP response body. This route should return a value that matches this type.
+   */
   post<RequestBody, ResponseBody>(
+    definition: RouteDefinition<Params, RequestBody, ResponseBody>
+  ): RouteBuilder<Params>;
+  /**
+   * Creates a DELETE route handler
+   * @template RequestBody The type of the HTTP request body. This should be validated by the `schema`.
+   * @template ResponseBody The type of the HTTP response body. This route should return a value that matches this type.
+   */
+  delete<RequestBody, ResponseBody>(
     definition: RouteDefinition<Params, RequestBody, ResponseBody>
   ): RouteBuilder<Params>;
 }
 
+/**
+ * Creates a route handler for a nextjs API route.
+ * The result of `build()` is exported and consumed by nextjs.
+ * @template Params The type of the URL parameters as defined in the nextjs file names.
+ */
 export default function createRoute<Params>(): RouteBuilder<Params> {
   const handlers: { [method: string]: NextApiHandler } = {};
 
@@ -145,6 +194,12 @@ export default function createRoute<Params>(): RouteBuilder<Params> {
       definition: RouteDefinition<Params, RequestBody, ResponseBody>
     ) {
       handlers['PATCH'] = createHandler(definition);
+      return this;
+    },
+    delete<RequestBody, ResponseBody>(
+      definition: RouteDefinition<Params, RequestBody, ResponseBody>
+    ) {
+      handlers['DELETE'] = createHandler(definition);
       return this;
     },
     build() {

--- a/packages/api/Route.ts
+++ b/packages/api/Route.ts
@@ -1,0 +1,66 @@
+import { ErrorResponse } from '@translation/api-types';
+import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
+
+export interface RequestData<Params, ResponseBody> {
+  req: NextApiRequest & { query: Params };
+  res: NextApiResponse<ResponseBody | ErrorResponse>;
+}
+
+export interface RouteDefinition<Params, ResponseBody> {
+  handler(data: RequestData<Params, ResponseBody>): Promise<void>;
+}
+
+export interface RouteBuilder<Params> {
+  build(): NextApiHandler;
+  get<ResponseBody>(
+    definition: RouteDefinition<Params, ResponseBody>
+  ): RouteBuilder<Params>;
+  patch<ResponseBody>(
+    definition: RouteDefinition<Params, ResponseBody>
+  ): RouteBuilder<Params>;
+  post<ResponseBody>(
+    definition: RouteDefinition<Params, ResponseBody>
+  ): RouteBuilder<Params>;
+}
+
+export default function createRoute<Params>(): RouteBuilder<Params> {
+  const handlers: { [method: string]: NextApiHandler } = {};
+
+  function createHandler<ResponseBody>(
+    definition: RouteDefinition<Params, ResponseBody>
+  ): NextApiHandler {
+    return async (req, res) => {
+      await definition.handler({
+        req: req as NextApiRequest & { query: Params },
+        res,
+      });
+    };
+  }
+
+  return {
+    get<ResponseBody>(definition: RouteDefinition<Params, ResponseBody>) {
+      handlers['GET'] = createHandler(definition);
+      return this;
+    },
+    post<ResponseBody>(definition: RouteDefinition<Params, ResponseBody>) {
+      handlers['POST'] = createHandler(definition);
+      return this;
+    },
+    patch<ResponseBody>(definition: RouteDefinition<Params, ResponseBody>) {
+      handlers['PATCH'] = createHandler(definition);
+      return this;
+    },
+    build() {
+      return (req: NextApiRequest, res: NextApiResponse) => {
+        const handler = handlers[req.method ?? ''];
+        if (handler) {
+          handler(req, res);
+        } else {
+          res.status(405).json({
+            errors: [{ code: 'MethodNotAllowed' }],
+          });
+        }
+      };
+    },
+  };
+}

--- a/packages/api/helpers.ts
+++ b/packages/api/helpers.ts
@@ -1,8 +1,0 @@
-import { ErrorResponse } from '@translation/api-types';
-import { NextApiRequest, NextApiResponse } from 'next';
-
-export type ApiRequest<Params = void> = Params extends void
-  ? NextApiRequest
-  : NextApiRequest & { query: Params };
-
-export type ApiResponse<Body = void> = NextApiResponse<Body | ErrorResponse>;

--- a/packages/api/pages/api/health.ts
+++ b/packages/api/pages/api/health.ts
@@ -1,9 +1,9 @@
-import { NextApiRequest, NextApiResponse } from 'next'
-import { client } from '../../db'
+import { NextApiRequest, NextApiResponse } from 'next';
+import { client } from '../../shared/db';
 
-export default async function(req: NextApiRequest, res: NextApiResponse) {
-  await client.book.count()
+export default async function (req: NextApiRequest, res: NextApiResponse) {
+  await client.book.count();
   return res.status(200).json({
-    databaseConnection: 'ok'
-  })
+    databaseConnection: 'ok',
+  });
 }

--- a/packages/api/pages/api/languages/[code].ts
+++ b/packages/api/pages/api/languages/[code].ts
@@ -4,9 +4,9 @@ import {
   PatchLanguageRequestBody,
   PatchLanguageResponseBody,
 } from '@translation/api-types';
-import { client, Prisma } from '../../../db';
+import { client, Prisma } from '../../../shared/db';
 import { languageSchema } from './schemas';
-import createRoute from '../../../Route';
+import createRoute from '../../../shared/Route';
 
 export default createRoute<{ code: string }>()
   .get<void, GetLanguageResponseBody>({

--- a/packages/api/pages/api/languages/index.ts
+++ b/packages/api/pages/api/languages/index.ts
@@ -1,26 +1,18 @@
 import * as z from 'zod';
-import { Prisma } from '../../../prisma/client';
 import {
   GetLanguagesResponseBody,
   PostLanguageRequestBody,
   PostLanguageResponseBody,
 } from '@translation/api-types';
-import { ApiRequest, ApiResponse } from '../../../helpers';
 import { client } from '../../../db';
 import { languageSchema } from './schemas';
+import createRoute from '../../../Route';
 
-const postRequestSchema: z.ZodType<PostLanguageRequestBody> = z.object({
-  data: languageSchema(),
-});
-
-export default async function (
-  req: ApiRequest,
-  res: ApiResponse<GetLanguagesResponseBody | PostLanguageResponseBody>
-) {
-  switch (req.method) {
-    case 'GET': {
+export default createRoute<void>()
+  .get<void, GetLanguagesResponseBody>({
+    async handler(req, res) {
       const languages = await client.language.findMany();
-      res.status(200).json({
+      res.ok({
         data: languages.map((language) => ({
           type: 'language',
           id: language.code,
@@ -35,67 +27,31 @@ export default async function (
           self: `${req.url}`,
         },
       });
-      break;
-    }
-    case 'POST': {
-      try {
-        let body;
-        const parseResult = postRequestSchema.safeParse(req.body);
-        if (parseResult.success) {
-          body = parseResult.data;
-        } else {
-          const { error } = parseResult;
-          const typeMismatch = error.issues.find(
-            (issue) => 'data.type' === issue.path.join('.')
-          );
-          if (typeMismatch) {
-            return res.status(409).json({
-              errors: [{ code: 'TypeMismatch' }],
-            });
-          } else {
-            return res.status(422).end({
-              errors: [{ code: 'InvalidRequestShape' }],
-            });
-          }
-        }
-
-        const language = await client.language.create({
-          data: {
-            code: body.data.id,
-            name: body.data.attributes.name,
-          },
-        });
-        res.status(201).json({
-          data: {
-            type: 'language',
-            id: language.code,
-            attributes: {
-              name: language.name,
-            },
-            links: {
-              self: `${req.url}/${language.code}`,
-            },
-          },
-        });
-      } catch (error) {
-        if (error instanceof Prisma.PrismaClientKnownRequestError) {
-          if (error.code === 'P2002') {
-            return res.status(409).json({
-              errors: [{ code: 'AlreadyExists' }],
-            });
-          } else {
-            throw error;
-          }
-        } else {
-          throw error;
-        }
-      }
-      break;
-    }
-    default: {
-      res.status(405).json({
-        errors: [{ code: 'MethodNotAllowed' }],
+    },
+  })
+  .post<PostLanguageRequestBody, PostLanguageResponseBody>({
+    schema: z.object({
+      data: languageSchema(),
+    }),
+    async handler(req, res) {
+      const language = await client.language.create({
+        data: {
+          code: req.body.data.id,
+          name: req.body.data.attributes.name,
+        },
       });
-    }
-  }
-}
+      res.created({
+        data: {
+          type: 'language',
+          id: language.code,
+          attributes: {
+            name: language.name,
+          },
+          links: {
+            self: `${req.url}/${language.code}`,
+          },
+        },
+      });
+    },
+  })
+  .build();

--- a/packages/api/pages/api/languages/index.ts
+++ b/packages/api/pages/api/languages/index.ts
@@ -4,9 +4,9 @@ import {
   PostLanguageRequestBody,
   PostLanguageResponseBody,
 } from '@translation/api-types';
-import { client } from '../../../db';
+import { client } from '../../../shared/db';
 import { languageSchema } from './schemas';
-import createRoute from '../../../Route';
+import createRoute from '../../../shared/Route';
 
 export default createRoute<void>()
   .get<void, GetLanguagesResponseBody>({

--- a/packages/api/pages/api/verse.ts
+++ b/packages/api/pages/api/verse.ts
@@ -1,16 +1,16 @@
-import { NextApiRequest, NextApiResponse } from 'next'
-import { client } from '../../db'
+import { NextApiRequest, NextApiResponse } from 'next';
+import { client } from '../../shared/db';
 
-export default async function(req: NextApiRequest, res: NextApiResponse) {
+export default async function (req: NextApiRequest, res: NextApiResponse) {
   const verse = await client.verse.findFirst({
     where: {
       number: 1,
       chapter: {
         number: 1,
         book: {
-          search: 'matthew'
+          search: 'matthew',
         },
-      } 
+      },
     },
     select: {
       number: true,
@@ -19,21 +19,21 @@ export default async function(req: NextApiRequest, res: NextApiResponse) {
           number: true,
           book: {
             select: {
-              name: true
-            }
-          }
-        }
-      }
-    }
-  })
+              name: true,
+            },
+          },
+        },
+      },
+    },
+  });
 
   if (verse) {
     res.status(200).json({
       book: verse.chapter.book.name,
       chapter: verse.chapter.number,
-      verse: verse.number
-    })
+      verse: verse.number,
+    });
   } else {
-    res.status(404)
+    res.status(404);
   }
 }

--- a/packages/api/shared/BaseError.ts
+++ b/packages/api/shared/BaseError.ts
@@ -1,0 +1,22 @@
+import { ErrorDetail } from '@translation/api-types';
+
+/**
+ * Base class for errors. Generates a code based on the error name.
+ */
+export default class BaseError extends Error {
+  readonly code: string;
+
+  constructor() {
+    super();
+    this.code = this.name.replace(/Error$/, '');
+    this.message = this.code;
+
+    Object.setPrototypeOf(this, BaseError.prototype);
+  }
+
+  toErrorDetail(): ErrorDetail {
+    return {
+      code: this.code,
+    };
+  }
+}

--- a/packages/api/shared/Route.ts
+++ b/packages/api/shared/Route.ts
@@ -1,7 +1,7 @@
 import { Error } from '@translation/api-types';
 import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
 import { ZodSchema } from 'zod';
-import { Prisma } from './prisma/client';
+import { Prisma } from '../prisma/client';
 
 export interface ResponseHelper<Body> {
   /** Returns 200 or 204 dependening on whether there is a response body to send. */

--- a/packages/api/shared/db.ts
+++ b/packages/api/shared/db.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Prisma } from './prisma/client';
+import { PrismaClient, Prisma } from '../prisma/client';
 
 export { Prisma };
 

--- a/packages/api/shared/errors.ts
+++ b/packages/api/shared/errors.ts
@@ -1,0 +1,17 @@
+import BaseError from './BaseError';
+
+export class MultiError extends Error {
+  constructor(
+    readonly responseType: 'invalid' | 'conflict' | 'notFound' | 'badRequest',
+    readonly errors: BaseError[]
+  ) {
+    super('Several errors occurred');
+    Object.setPrototypeOf(this, MultiError.prototype);
+  }
+}
+
+export class NotFoundError extends BaseError {}
+export class AlreadyExistsError extends BaseError {}
+export class InvalidRequestShapeError extends BaseError {}
+export class TypeMismatchError extends BaseError {}
+export class IdMismatchError extends BaseError {}


### PR DESCRIPTION
My goal here was to simplify and standardize how we create API route handlers. The docs do a pretty good job of spelling out what that process looks like. In general my goals were:

1. Enforce request response types to keep the API and clients in sync. This means validating requests against a typescript interface, and enforcing the response body type.
2. Simplify error handling by converting thrown errors to an HTTP response with a unique code that can be localized on the frontend if displayed.

closes #41