### PR TITLE
refactor: remove json api

### DIFF
--- a/packages/api-client/src/languages.ts
+++ b/packages/api-client/src/languages.ts
@@ -2,9 +2,7 @@ import type {
   GetLanguageResponseBody,
   GetLanguagesResponseBody,
   PatchLanguageRequestBody,
-  PatchLanguageResponseBody,
   PostLanguageRequestBody,
-  PostLanguageResponseBody,
 } from '@translation/api-types';
 import type ApiClient from './client';
 
@@ -12,9 +10,7 @@ export {
   GetLanguageResponseBody,
   GetLanguagesResponseBody,
   PatchLanguageRequestBody,
-  PatchLanguageResponseBody,
   PostLanguageRequestBody,
-  PostLanguageResponseBody,
 };
 
 export default class Languages {
@@ -26,8 +22,8 @@ export default class Languages {
     });
   }
 
-  create(language: PostLanguageRequestBody): Promise<PostLanguageResponseBody> {
-    return this.client.post({
+  async create(language: PostLanguageRequestBody): Promise<void> {
+    await this.client.post({
       path: '/api/languages',
       body: language,
     });
@@ -39,11 +35,12 @@ export default class Languages {
     });
   }
 
-  update(
+  async update(
+    code: string,
     language: PatchLanguageRequestBody
-  ): Promise<PatchLanguageResponseBody> {
-    return this.client.patch({
-      path: `/api/languages/${language.data.id}`,
+  ): Promise<void> {
+    await this.client.patch({
+      path: `/api/languages/${code}`,
       body: language,
     });
   }

--- a/packages/api-types/src/language.ts
+++ b/packages/api-types/src/language.ts
@@ -1,43 +1,16 @@
-export interface LanguageResourceIdentifier {
-  type: 'language';
-  id: string;
-}
-
-export interface Language extends LanguageResourceIdentifier {
-  attributes: {
-    name: string;
-  };
-}
-
-export interface LanguageWithLinks extends Language {
-  links: {
-    self: string;
-  };
+export interface Language {
+  code: string;
+  name: string;
 }
 
 export interface GetLanguagesResponseBody {
-  data: LanguageWithLinks[];
-  links: {
-    self: string;
-  };
+  data: Language[];
 }
 
 export interface GetLanguageResponseBody {
-  data: LanguageWithLinks;
-}
-
-export interface PostLanguageRequestBody {
   data: Language;
 }
 
-export interface PostLanguageResponseBody {
-  data: LanguageWithLinks;
-}
+export type PostLanguageRequestBody = Language;
 
-export interface PatchLanguageRequestBody {
-  data: Language;
-}
-
-export interface PatchLanguageResponseBody {
-  data: LanguageWithLinks;
-}
+export type PatchLanguageRequestBody = Partial<Omit<Language, 'code'>>;

--- a/packages/api/pages/api/languages/index.ts
+++ b/packages/api/pages/api/languages/index.ts
@@ -2,7 +2,6 @@ import * as z from 'zod';
 import {
   GetLanguagesResponseBody,
   PostLanguageRequestBody,
-  PostLanguageResponseBody,
 } from '@translation/api-types';
 import { client } from '../../../shared/db';
 import { languageSchema } from './schemas';
@@ -14,44 +13,22 @@ export default createRoute<void>()
       const languages = await client.language.findMany();
       res.ok({
         data: languages.map((language) => ({
-          type: 'language',
-          id: language.code,
-          attributes: {
-            name: language.name,
-          },
-          links: {
-            self: `${req.url}/${language.code}`,
-          },
+          code: language.code,
+          name: language.name,
         })),
-        links: {
-          self: `${req.url}`,
-        },
       });
     },
   })
-  .post<PostLanguageRequestBody, PostLanguageResponseBody>({
-    schema: z.object({
-      data: languageSchema(),
-    }),
+  .post<PostLanguageRequestBody, void>({
+    schema: languageSchema,
     async handler(req, res) {
-      const language = await client.language.create({
+      await client.language.create({
         data: {
-          code: req.body.data.id,
-          name: req.body.data.attributes.name,
+          code: req.body.code,
+          name: req.body.name,
         },
       });
-      res.created({
-        data: {
-          type: 'language',
-          id: language.code,
-          attributes: {
-            name: language.name,
-          },
-          links: {
-            self: `${req.url}/${language.code}`,
-          },
-        },
-      });
+      res.created(`/api/languages/${req.body.code}`);
     },
   })
   .build();

--- a/packages/api/pages/api/languages/schemas.ts
+++ b/packages/api/pages/api/languages/schemas.ts
@@ -1,11 +1,15 @@
 import * as z from 'zod';
 import { Language } from '@translation/api-types';
 
-export const languageSchema = (id?: string): z.ZodType<Language> =>
+const schemaForType =
+  <T>() =>
+  <S extends z.ZodType<T, any, any>>(arg: S) => {
+    return arg;
+  };
+
+export const languageSchema = schemaForType<Language>()(
   z.object({
-    type: z.literal('language'),
-    id: id ? z.literal(id) : z.string(),
-    attributes: z.object({
-      name: z.string(),
-    }),
-  });
+    code: z.string(),
+    name: z.string(),
+  })
+);

--- a/packages/api/public/spec/paths/language.yml
+++ b/packages/api/public/spec/paths/language.yml
@@ -35,31 +35,11 @@ patch:
         schema:
           type: object
           properties:
-            data:
-              type: object
-              properties:
-                type:
-                  type: string
-                  enum: [language]
-                id:
-                  type: string
-                  example: es
-                  description: The [IETF language code](https://en.wikipedia.org/wiki/IETF_language_tag).
-                attributes:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                      example: Español
-                      description: The name of the language in the language itself.
+            name:
+              type: string
+              example: Español
+              description: The name of the language in the language itself.
   responses:
-    "200":
-      description: Ok
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              data:
-                $ref: "../schemas/language.yml"
+    "204":
+      description: No Content
             

--- a/packages/api/public/spec/paths/languages.yml
+++ b/packages/api/public/spec/paths/languages.yml
@@ -14,25 +14,10 @@ get:
                     items:
                       $ref: "../schemas/language.yml"
                   - example:
-                    - type: language
-                      id: es 
-                      attributes:
-                        name: Español
-                      links: 
-                        self: /languages/es
-                    - type: language
-                      id: en 
-                      attributes:
-                        name: English
-                      links: 
-                        self: /languages/en
-              links:
-                type: object
-                properties:
-                  self:
-                    type: string
-                    format: uri
-                    example: '/languages'
+                    - code: es 
+                      name: Español
+                    - code: en 
+                      name: English
 post:
   summary: Create a new language to translate.
   requestBody:
@@ -42,30 +27,20 @@ post:
         schema:
           type: object
           properties:
-            data:
-              type: object
-              properties:
-                type:
-                  type: string
-                  enum: [language]
-                id:
-                  type: string
-                  example: es
-                  description: The [IETF language code](https://en.wikipedia.org/wiki/IETF_language_tag).
-                attributes:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                      example: Español
-                      description: The name of the language in the language itself.
+            code:
+              type: string
+              example: es
+              description: The [IETF language code](https://en.wikipedia.org/wiki/IETF_language_tag).
+            name:
+              type: string
+              example: Español
+              description: The name of the language in the language itself.
   responses:
     201:
       description: Created
-      content:
-        application/json:
+      headers:
+        Location:
           schema:
-            type: object
-            properties:
-              data:
-                $ref: "../schemas/language.yml"
+            type: string
+          description: URL to new language.
+      

--- a/packages/api/public/spec/schemas/language.yml
+++ b/packages/api/public/spec/schemas/language.yml
@@ -1,23 +1,10 @@
 type: object
 properties:
-  type:
-    type: string
-    enum: [language]
-  id:
+  code:
     type: string
     example: es
     description: The [IETF language code](https://en.wikipedia.org/wiki/IETF_language_tag).
-  attributes:
-    type: object
-    properties:
-      name:
-        type: string
-        example: Español
-        description: The name of the language in the language itself.
-  links:
-    type: object
-    properties:
-      self:
-        type: string
-        format: uri
-        example: '/languages/es'
+  name:
+    type: string
+    example: Español
+    description: The name of the language in the language itself.

--- a/packages/api/shared/BaseError.ts
+++ b/packages/api/shared/BaseError.ts
@@ -10,8 +10,6 @@ export default class BaseError extends Error {
     super();
     this.code = this.name.replace(/Error$/, '');
     this.message = this.code;
-
-    Object.setPrototypeOf(this, BaseError.prototype);
   }
 
   toErrorDetail(): ErrorDetail {

--- a/packages/api/shared/errors.ts
+++ b/packages/api/shared/errors.ts
@@ -1,17 +1,5 @@
 import BaseError from './BaseError';
 
-export class MultiError extends Error {
-  constructor(
-    readonly responseType: 'invalid' | 'conflict' | 'notFound' | 'badRequest',
-    readonly errors: BaseError[]
-  ) {
-    super('Several errors occurred');
-    Object.setPrototypeOf(this, MultiError.prototype);
-  }
-}
-
 export class NotFoundError extends BaseError {}
 export class AlreadyExistsError extends BaseError {}
 export class InvalidRequestShapeError extends BaseError {}
-export class TypeMismatchError extends BaseError {}
-export class IdMismatchError extends BaseError {}

--- a/packages/web/src/app/Header.tsx
+++ b/packages/web/src/app/Header.tsx
@@ -24,7 +24,7 @@ export default function Header({ language, onLanguageChange }: HeaderProps) {
   const translationLanguages = useLoaderData() as GetLanguagesResponseBody;
 
   const selectedLanguage = translationLanguages.data.find(
-    (l) => l.id === language
+    (l) => l.code === language
   );
 
   return (
@@ -33,16 +33,16 @@ export default function Header({ language, onLanguageChange }: HeaderProps) {
       <div className="flex-grow" />
       <nav className="flex items-baseline" aria-label="primary">
         <DropdownMenu
-          text={selectedLanguage?.attributes.name ?? 'Language'}
+          text={selectedLanguage?.name ?? 'Language'}
           className="mr-4"
         >
           <DropdownMenuSubmenu text={t('switch_language')}>
             {translationLanguages.data.map((language) => (
               <DropdownMenuButton
-                key={language.id}
-                onClick={() => onLanguageChange(language.id)}
+                key={language.code}
+                onClick={() => onLanguageChange(language.code)}
               >
-                {language.attributes.name}
+                {language.name}
               </DropdownMenuButton>
             ))}
           </DropdownMenuSubmenu>

--- a/packages/web/src/app/Layout.tsx
+++ b/packages/web/src/app/Layout.tsx
@@ -21,12 +21,12 @@ export function Layout() {
   const languages = useLoaderData() as GetLanguagesResponseBody;
   const [language, selectLanguage] = useLocalStorageState<string>(
     'translation-language',
-    languages.data[0]?.id
+    languages.data[0]?.code
   );
 
   const outletContext = useMemo<LayoutContext>(
     () => ({
-      language: languages.data.find((l) => l.id === language),
+      language: languages.data.find((l) => l.code === language),
     }),
     [language, languages]
   );

--- a/packages/web/src/features/languages/LanguageView.tsx
+++ b/packages/web/src/features/languages/LanguageView.tsx
@@ -45,10 +45,10 @@ export default function LanguagesView() {
           </ListRowAction>
           <ListBody>
             {languages.data.map((language) => (
-              <ListRow key={language.id}>
-                <ListCell header>{language.attributes.name}</ListCell>
+              <ListRow key={language.code}>
+                <ListCell header>{language.name}</ListCell>
                 <ListCell>
-                  <Link to={`./${language.id}`}>{t('manage')}</Link>
+                  <Link to={`./${language.code}`}>{t('manage')}</Link>
                 </ListCell>
               </ListRow>
             ))}

--- a/packages/web/src/features/languages/ManageLanguageView.tsx
+++ b/packages/web/src/features/languages/ManageLanguageView.tsx
@@ -23,21 +23,15 @@ export default function ManageLanguageView() {
     const name = (
       e.currentTarget.elements.namedItem('name') as HTMLInputElement
     ).value;
-    await apiClient.languages.update({
-      data: {
-        type: 'language',
-        id: language.data.id,
-        attributes: {
-          name,
-        },
-      },
+    await apiClient.languages.update(language.data.code, {
+      name,
     });
   }
 
   return (
     <View fitToScreen>
       <div className="m-auto w-fit">
-        <ViewTitle>{language.data.attributes.name}</ViewTitle>
+        <ViewTitle>{language.data.name}</ViewTitle>
 
         <form onSubmit={onSubmit}>
           <div className="mb-4">
@@ -47,7 +41,7 @@ export default function ManageLanguageView() {
               name="name"
               className="block"
               autoComplete="off"
-              defaultValue={language.data.attributes.name}
+              defaultValue={language.data.name}
               required
             />
           </div>

--- a/packages/web/src/features/languages/NewLanguageView.tsx
+++ b/packages/web/src/features/languages/NewLanguageView.tsx
@@ -24,13 +24,8 @@ export default function NewLanguageView() {
     ).value;
     try {
       await apiClient.languages.create({
-        data: {
-          type: 'language',
-          id: code,
-          attributes: {
-            name,
-          },
-        },
+        code,
+        name,
       });
     } catch (error) {
       if (error instanceof ApiClientError && error.status === 409) {

--- a/packages/web/src/features/translation/TranslationView.tsx
+++ b/packages/web/src/features/translation/TranslationView.tsx
@@ -5,7 +5,7 @@ export default function TranslationView() {
 
   return (
     <div className="absolute w-full h-full flex items-center justify-center">
-      selected language: {language?.attributes.name ?? 'None'}
+      selected language: {language?.name ?? 'None'}
     </div>
   );
 }


### PR DESCRIPTION
I originally thought an API design spec like JSON:API was going to be useful, but I went to start thinking about routes for verse data and realized that it adds a lot of unnecessary complexity as this stage. I really want to strike a balance between using useful tools to accelerate development, without saddling us with unnecessary constraints.