### PR TITLE
fix: nahum data

### DIFF
--- a/data/morphology.ts
+++ b/data/morphology.ts
@@ -32,7 +32,7 @@ const bookFiles = [
   'Oba.json',
   'Jon.json',
   'Mic.json',
-  'Neh.json',
+  'Nam.json',
   'Hab.json',
   'Zep.json',
   'Hag.json',


### PR DESCRIPTION
The `bookFiles` array has a typo in the Nahum entry, causing the Nahum data to not be updated correctly. We might need to generate a new `seed.dump` file?