### PR TITLE
build: reconfigure preview domains for vercel pro

### DIFF
--- a/packages/api/shared/env.ts
+++ b/packages/api/shared/env.ts
@@ -1,6 +1,7 @@
-const originSuffix = `${process.env.VERCEL_GIT_COMMIT_REF?.replace('/', '-')}-${
-  process.env.VERCEL_GIT_REPO_OWNER ?? ''
-}.vercel.app`;
+const originSuffix = `${process.env.VERCEL_GIT_COMMIT_REF?.replace(
+  '/',
+  '-'
+)}-global-bible-tools.vercel.app`;
 
 export const origin =
   process.env.VERCEL_ENV === 'preview'
@@ -9,7 +10,7 @@ export const origin =
 export const originAllowlist =
   process.env.VERCEL_ENV === 'preview'
     ? [
-        `https://gloss-translation-api-git-${originSuffix}`,
-        `https://gloss-translation-git-${originSuffix}`,
+        `https://api-git-${originSuffix}`,
+        `https://interlinear-git-${originSuffix}`,
       ]
     : process.env.ORIGIN_ALLOWLIST?.split(',') ?? [];

--- a/packages/web/webpack.config.js
+++ b/packages/web/webpack.config.js
@@ -9,10 +9,10 @@ module.exports = composePlugins(withNx(), withReact(), (config) => {
       // Generate the API_URL for vercel preview environments since these are unique for each branch.
       'process.env.API_URL': JSON.stringify(
         process.env.VERCEL_ENV === 'preview'
-          ? `https://gloss-translation-api-git-${process.env.VERCEL_GIT_COMMIT_REF.replace(
+          ? `https://api-git-${process.env.VERCEL_GIT_COMMIT_REF.replace(
               '/',
               '-'
-            )}-${process.env.VERCEL_GIT_REPO_OWNER}.vercel.app`
+            )}-global-bible-tools.vercel.app`
           : process.env.API_URL
       ),
     })

--- a/vercel.json
+++ b/vercel.json
@@ -15,7 +15,7 @@
       "has": [
         {
           "type": "host",
-          "value": "gloss-translation(?<host>-(?!api).*|).vercel.app"
+          "value": "interlinear-git-(?<branch>.*)-global-bible-tools.vercel.app"
         }
       ],
       "destination": "/"


### PR DESCRIPTION
<!--
  Thank you for your PR! Please follow this template to help us review your PR quickly.
-->

## What has changed

<!--
  Please name your PR following conventional commits.
  https://www.conventionalcommits.org/en/v1.0.0/
  The main ones to use are `feat`, `fix`, `chore`, `build`, `refactor`, and `docs`.

  If your PR is not connected to an issue, please describe the reason for your
  changes. Please also describe what you have changed. For more complex changes, include a self review that goes into more detail. Please also call attention to breaking changes, particularly in the shape of API routes.
-->

Now that we are on vercel pro, the preview domains have changed. They also can get quite long, so I shortened the project names since they are in a team and not in my personal account. Now the URLs have the shape `https://interlinear-git-<branch-name>-global-bible-tools.vercel.app` and `https://api-git-<branch-name>-global-bible-tools.vercel.app`.

## Connected Issues

<!--
  If this PR resolves an issue, please add `closes #issue-no` below to connect the issue to the PR.
-->

## QA Steps

<!-- Please describe how to test what you've changed. -->

Open the preview app and confirm that the frontend and can make requests to the api

## Post-Deployment

<!--
  Please describe any tasks that must be executed after this change is deployed.
-->

- [x] Nothing required
