### PR TITLE
feat: handle diacritics gracefully

### DIFF
--- a/packages/api/pages/api/languages/[code]/words/[wordId].ts
+++ b/packages/api/pages/api/languages/[code]/words/[wordId].ts
@@ -26,6 +26,8 @@ export default createRoute<{ code: string; wordId: string }>()
         return;
       }
 
+      const normalizedGloss = req.body.gloss?.normalize('NFD');
+
       await client.gloss.upsert({
         where: {
           wordId_languageId: {
@@ -34,12 +36,12 @@ export default createRoute<{ code: string; wordId: string }>()
           },
         },
         update: {
-          gloss: req.body.gloss,
+          gloss: normalizedGloss,
         },
         create: {
           wordId: req.query.wordId,
           languageId: language.id,
-          gloss: req.body.gloss,
+          gloss: normalizedGloss,
         },
       });
 

--- a/packages/web/src/shared/components/form/AutocompleteInput.tsx
+++ b/packages/web/src/shared/components/form/AutocompleteInput.tsx
@@ -42,12 +42,12 @@ const AutocompleteInput = ({
     if (normalizedInputValue) {
       const filteredItems = items.filter((item) =>
         item.label
-          .normalize()
+          .normalize('NFD')
           .toLowerCase()
           .includes(normalizedInputValue.toLowerCase())
       );
       const noExactMatch = filteredItems.every(
-        (item) => item.label.normalize() !== normalizedInputValue
+        (item) => item.label.normalize('NFD') !== normalizedInputValue
       );
       if (noExactMatch && !!onCreate) {
         setFilteredItems([
@@ -88,7 +88,7 @@ const AutocompleteInput = ({
           <Combobox.Input
             {...props}
             onChange={(event) =>
-              setNormalizedInputValue(event.target.value.normalize())
+              setNormalizedInputValue(event.target.value.normalize('NFD'))
             }
             onBlur={onBlur}
             className="w-full py-2 px-3 h-10 rounded-b flex-grow focus:outline-none bg-transparent rounded"

--- a/packages/web/src/shared/components/form/AutocompleteInput.tsx
+++ b/packages/web/src/shared/components/form/AutocompleteInput.tsx
@@ -46,9 +46,7 @@ const AutocompleteInput = ({
         )
       );
       const noExactMatch = filteredItems.every(
-        (item) =>
-          ignoreDiacritics(item.label.normalize('NFD')) !==
-          ignoreDiacritics(normalizedInputValue)
+        (item) => item.label.normalize('NFD') !== normalizedInputValue
       );
       if (noExactMatch && !!onCreate) {
         setFilteredItems([

--- a/packages/web/src/shared/components/form/AutocompleteInput.tsx
+++ b/packages/web/src/shared/components/form/AutocompleteInput.tsx
@@ -42,7 +42,7 @@ const AutocompleteInput = ({
     if (normalizedInputValue) {
       const filteredItems = items.filter((item) =>
         ignoreDiacritics(item.label.normalize('NFD').toLowerCase()).includes(
-          normalizedInputValue.toLowerCase()
+          ignoreDiacritics(normalizedInputValue.toLowerCase())
         )
       );
       const noExactMatch = filteredItems.every(
@@ -121,7 +121,11 @@ const AutocompleteInput = ({
   );
 };
 
+/**
+ * Return a version of the word where all diacritics have been removed.
+ */
 function ignoreDiacritics(word: string) {
+  // From https://stackoverflow.com/a/37511463
   return word.normalize('NFD').replace(/\p{Diacritic}/gu, '');
 }
 

--- a/packages/web/src/shared/components/form/AutocompleteInput.tsx
+++ b/packages/web/src/shared/components/form/AutocompleteInput.tsx
@@ -41,13 +41,14 @@ const AutocompleteInput = ({
   useEffect(() => {
     if (normalizedInputValue) {
       const filteredItems = items.filter((item) =>
-        item.label
-          .normalize('NFD')
-          .toLowerCase()
-          .includes(normalizedInputValue.toLowerCase())
+        ignoreDiacritics(item.label.normalize('NFD').toLowerCase()).includes(
+          normalizedInputValue.toLowerCase()
+        )
       );
       const noExactMatch = filteredItems.every(
-        (item) => item.label.normalize('NFD') !== normalizedInputValue
+        (item) =>
+          ignoreDiacritics(item.label.normalize('NFD')) !==
+          ignoreDiacritics(normalizedInputValue)
       );
       if (noExactMatch && !!onCreate) {
         setFilteredItems([
@@ -119,5 +120,9 @@ const AutocompleteInput = ({
     </div>
   );
 };
+
+function ignoreDiacritics(word: string) {
+  return word.normalize('NFD').replace(/\p{Diacritic}/gu, '');
+}
 
 export default AutocompleteInput;


### PR DESCRIPTION
<!--
  Thank you for your PR! Please follow this template to help us review your PR quickly.
-->

## What has changed

<!--
  Please name your PR following conventional commits.
  https://www.conventionalcommits.org/en/v1.0.0/
  The main ones to use are `feat`, `fix`, `chore`, `build`, `refactor`, and `docs`.

  If your PR is not connected to an issue, please describe the reason for your
  changes. Please also describe what you have changed. For more complex changes, include a self review that goes into more detail. Please also call attention to breaking changes, particularly in the shape of API routes.
-->
Improved diacritics handling.

## Connected Issues

<!--
  If this PR resolves an issue, please add `closes #issue-no` below to connect the issue to the PR.
-->

#84 
## QA Steps

<!-- Please describe how to test what you've changed. -->

### Backend normalization
The easiest way to test this is to add these debug messages in `[wordId.ts]`:
```
      console.log('BEFORE:', new TextEncoder().encode(req.body.gloss ?? ""));
      const normalizedGloss = req.body.gloss?.normalize('NFD');
      console.log('AFTER:', new TextEncoder().encode(normalizedGloss ?? ""));
```
You'll also need to temporarily disable the frontend normalization in `AutocompleteInput.tsx`:
```
              setNormalizedInputValue(event.target.value)
```

1. Enter "è" as a gloss in the frontend. Select the create option in the dropdown.
2. Check the backend logs
  * You should see something like:
```
BEFORE: Uint8Array(2) [ 195, 168 ]
AFTER: Uint8Array(3) [ 101, 204, 128 ]
```
  * This means the "è" has been successfully decomposed.


### Ignore diacritics
1. Enter "tèst" as a gloss for a word. Make sure the gloss saved
1. Type "test" in the same autocomplete.
    * It should match "tèst", and have no create option
1. Repeat steps 1 and 2 on a different word, but initially save "test" as the gloss, and check that "tèst" matches it.



## Post-Deployment

<!--
  Please describe any tasks that must be executed after this change is deployed.
-->

- [x] Nothing required
