### PR TITLE
fix: reconfigure react query to load fresh data for each view

### DIFF
--- a/packages/web/src/shared/hooks/useAuth.ts
+++ b/packages/web/src/shared/hooks/useAuth.ts
@@ -18,7 +18,10 @@ export const sessionQuery = {
 
 /** Get the status and data in the current session. */
 export default function useAuth(): UseAuthResult {
-  const { data, status } = useQuery(sessionQuery);
+  const { data, status } = useQuery({
+    ...sessionQuery,
+    refetchOnMount: true,
+  });
 
   const queryClient = useQueryClient();
   const refreshAuth = useCallback(() => {

--- a/packages/web/src/shared/queryClient.tsx
+++ b/packages/web/src/shared/queryClient.tsx
@@ -9,5 +9,8 @@ queryClient.setDefaultOptions({
     // If a query is invalidated, it will still be refetched,
     // but this prevents continually refetching queries that are used in multiple places like the user session.
     staleTime: 10 * 60 * 1000, // 10 minutes,
+    // We always refetch on mount so that during navigation after changes, data is refreshed.
+    // This reduces the need to invalid individual queries at the expense of extra requests on navigation.
+    refetchOnMount: 'always',
   },
 });


### PR DESCRIPTION
<!--
  Thank you for your PR! Please follow this template to help us review your PR quickly.
-->

## What has changed

I changed the default setting for queries so that they refetch data when a new view loads. This means the data could be stale until the new data is loaded. The alternative is to require that mutations specify all the possible queries that need to be reloaded.

<!--
  Please name your PR following conventional commits.
  https://www.conventionalcommits.org/en/v1.0.0/
  The main ones to use are `feat`, `fix`, `chore`, `build`, `refactor`, and `docs`.

  If your PR is not connected to an issue, please describe the reason for your
  changes. Please also describe what you have changed. For more complex changes, include a self review that goes into more detail. Please also call attention to breaking changes, particularly in the shape of API routes.
-->

## Connected Issues

<!--
  If this PR resolves an issue, please add `closes #issue-no` below to connect the issue to the PR.
-->
closes #169 

## QA Steps

<!-- Please describe how to test what you've changed. -->

1. Log in as an admin
2. Go to users page
3. Go to profile page and change your name
4. Go back to users page and look for your name to change

## Post-Deployment

<!--
  Please describe any tasks that must be executed after this change is deployed.
-->

- [x] Nothing required
