### PR TITLE
refactor: up and down arrow directions for verse selector

### DIFF
--- a/packages/web/src/features/translation/VerseSelector.tsx
+++ b/packages/web/src/features/translation/VerseSelector.tsx
@@ -43,13 +43,11 @@ export function VerseSelector({ verseId, onVerseChange }: VerseSelectorProps) {
         arial-label={t('select_verse')}
       />
       <button onClick={() => onVerseChange(decrementVerseId(verseId))}>
-        <Icon icon="arrow-left" className="rtl:hidden" />
-        <Icon icon="arrow-right" className="ltr:hidden" />
+        <Icon icon="arrow-up" />
         <span className="sr-only">{t('previous_verse')}</span>
       </button>
       <button onClick={() => onVerseChange(incrementVerseId(verseId))}>
-        <Icon icon="arrow-right" className="rtl:hidden" />
-        <Icon icon="arrow-left" className="ltr:hidden" />
+        <Icon icon="arrow-down" />
         <span className="sr-only">{t('next_verse')}</span>
       </button>
     </div>

--- a/packages/web/src/shared/components/Icon.tsx
+++ b/packages/web/src/shared/components/Icon.tsx
@@ -13,8 +13,8 @@ library.add(
   FaSolid.faPlus,
   FaSolid.faCheck,
   FaSolid.faArrowsRotate,
-  FaSolid.faArrowLeft,
-  FaSolid.faArrowRight,
+  FaSolid.faArrowUp,
+  FaSolid.faArrowDown,
   FaSolid.faRightFromBracket,
   FaSolid.faExclamationTriangle,
   FaSolid.faFileImport


### PR DESCRIPTION
<!--
  Thank you for your PR! Please follow this template to help us review your PR quickly.
-->

## What has changed

* Switched to up and down arrows for the verse selector buttons. That makes it clearer which way the verse changes regardless of language orientation

<!--
  Please name your PR following conventional commits.
  https://www.conventionalcommits.org/en/v1.0.0/
  The main ones to use are `feat`, `fix`, `chore`, `build`, `refactor`, and `docs`.

  If your PR is not connected to an issue, please describe the reason for your
  changes. Please also describe what you have changed. For more complex changes, include a self review that goes into more detail. Please also call attention to breaking changes, particularly in the shape of API routes.
-->

## Connected Issues

closes #181 

<!--
  If this PR resolves an issue, please add `closes #issue-no` below to connect the issue to the PR.
-->

## QA Steps

1. Go to the translation view
2. Use the arrow buttons
3. Confirm verse changes as you'd expect

<!-- Please describe how to test what you've changed. -->

## Post-Deployment

<!--
  Please describe any tasks that must be executed after this change is deployed.
-->

- [x] Nothing required
