### PR TITLE
refactor: make chapter and verse optional when parsing reference

### DIFF
--- a/packages/web/src/features/translation/verse-utils.ts
+++ b/packages/web/src/features/translation/verse-utils.ts
@@ -139,7 +139,7 @@ export function bookName(bookId: number, t: TFunction) {
  * @returns The verse ID if it can be determined, otherwise `null`.
  */
 export function parseReference(reference: string, t: TFunction): string | null {
-  const referenceRegex = /^(.+)\s+(\d+)([:.,]|\s+)(\d+)$/;
+  const referenceRegex = /^(.+?)(:?\s+(\d+)(?:([:.,]|\s+)(\d+))?)?$/;
 
   // Parse the reference into three parts.
   const matches = reference.match(referenceRegex);
@@ -164,13 +164,13 @@ export function parseReference(reference: string, t: TFunction): string | null {
   }
 
   // Coerce the chapter number to be valid.
-  const chapterNumber = clamp(parseInt(chapterStr), 1, chapterCount(bookId));
+  const chapterNumber = chapterStr
+    ? clamp(parseInt(chapterStr), 1, chapterCount(bookId))
+    : 1;
   // Coerce the verse number to be valid.
-  const verseNumber = clamp(
-    parseInt(verseStr),
-    1,
-    verseCount(bookId, chapterNumber)
-  );
+  const verseNumber = verseStr
+    ? clamp(parseInt(verseStr), 1, verseCount(bookId, chapterNumber))
+    : 1;
   return generateVerseId({ bookId, chapterNumber, verseNumber });
 }
 

--- a/packages/web/src/features/translation/verse-utils.ts
+++ b/packages/web/src/features/translation/verse-utils.ts
@@ -139,7 +139,7 @@ export function bookName(bookId: number, t: TFunction) {
  * @returns The verse ID if it can be determined, otherwise `null`.
  */
 export function parseReference(reference: string, t: TFunction): string | null {
-  const referenceRegex = /^(.+?)(:?\s+(\d+)(?:([:.,]|\s+)(\d+))?)?$/;
+  const referenceRegex = /^(.+?)(?:\s+(\d+)(?:([:.,]|\s+)(\d+))?)?$/;
 
   // Parse the reference into three parts.
   const matches = reference.match(referenceRegex);


### PR DESCRIPTION
<!--
  Thank you for your PR! Please follow this template to help us review your PR quickly.
-->

## What has changed

verse and chapter numbers are now optional when you type in a reference. It will fall back to chapter 1 and verse 1 if not provided.

<!--
  Please name your PR following conventional commits.
  https://www.conventionalcommits.org/en/v1.0.0/
  The main ones to use are `feat`, `fix`, `chore`, `build`, `refactor`, and `docs`.

  If your PR is not connected to an issue, please describe the reason for your
  changes. Please also describe what you have changed. For more complex changes, include a self review that goes into more detail. Please also call attention to breaking changes, particularly in the shape of API routes.
-->

## Connected Issues
closes #185 

<!--
  If this PR resolves an issue, please add `closes #issue-no` below to connect the issue to the PR.
-->

## QA Steps

1. In the translation view, try typing Psalm 100 and Obadiah.
2. In both cases it should fill in the chapter and verse number that are missing

<!-- Please describe how to test what you've changed. -->

## Post-Deployment

<!--
  Please describe any tasks that must be executed after this change is deployed.
-->

- [x] Nothing required
