### PR TITLE
refactor: prefetch the next 3 verses while translating

### DIFF
--- a/packages/web/src/features/translation/TranslationView.tsx
+++ b/packages/web/src/features/translation/TranslationView.tsx
@@ -7,13 +7,55 @@ import apiClient from '../../shared/apiClient';
 import LoadingSpinner from '../../shared/components/LoadingSpinner';
 import TranslateWord from './TranslateWord';
 import { VerseSelector } from './VerseSelector';
-import { parseVerseId } from './verse-utils';
+import { incrementVerseId, parseVerseId } from './verse-utils';
 import DropdownMenu, {
   DropdownMenuLink,
 } from '../../shared/components/actions/DropdownMenu';
 
 export const translationLanguageKey = 'translation-language';
 export const translationVerseIdKey = 'translation-verse-id';
+
+const VERSES_TO_PREFETCH = 3;
+
+function useTranslationQueries(language: string, verseId: string) {
+  const verseQuery = useQuery(['verse', verseId], () =>
+    apiClient.verses.findById(verseId)
+  );
+  const referenceGlossesQuery = useQuery(['verse-glosses', 'en', verseId], () =>
+    apiClient.verses.findVerseGlosses(verseId, 'en')
+  );
+  const targetGlossesQuery = useQuery(
+    ['verse-glosses', language, verseId],
+    () => apiClient.verses.findVerseGlosses(verseId, language)
+  );
+
+  const queryClient = useQueryClient();
+
+  // This primes the cache with verse data for the next VERSES_TO_PREFETCH verses.
+  // API requests are only sent if there is no data in the cache for the verse.
+  useEffect(() => {
+    let nextVerseId = verseId;
+    for (let i = 0; i < VERSES_TO_PREFETCH; i++) {
+      nextVerseId = incrementVerseId(nextVerseId);
+      queryClient.ensureQueryData({
+        queryKey: ['verse', nextVerseId],
+        queryFn: ({ queryKey }) => apiClient.verses.findById(queryKey[1]),
+      });
+      queryClient.ensureQueryData({
+        queryKey: ['verse-glosses', 'en', nextVerseId],
+        queryFn: ({ queryKey }) =>
+          apiClient.verses.findVerseGlosses(queryKey[2], 'en'),
+      });
+      queryClient.ensureQueryData({
+        queryKey: ['verse-glosses', language, nextVerseId],
+        queryFn: ({ queryKey }) =>
+          apiClient.verses.findVerseGlosses(queryKey[2], queryKey[1]),
+      });
+    }
+  }, [language, verseId, queryClient]);
+
+  return { verseQuery, referenceGlossesQuery, targetGlossesQuery };
+}
 
 export default function TranslationView() {
   const { language, verseId } = useParams() as {
@@ -31,16 +73,8 @@ export default function TranslationView() {
 
   const navigate = useNavigate();
 
-  const verseQuery = useQuery(['verse', verseId], () =>
-    apiClient.verses.findById(verseId)
-  );
-  const referenceGlossesQuery = useQuery(['verse-glosses', 'en', verseId], () =>
-    apiClient.verses.findVerseGlosses(verseId, 'en')
-  );
-  const targetGlossesQuery = useQuery(
-    ['verse-glosses', language, verseId],
-    () => apiClient.verses.findVerseGlosses(verseId, language)
-  );
+  const { verseQuery, referenceGlossesQuery, targetGlossesQuery } =
+    useTranslationQueries(language, verseId);
 
   const languagesQuery = useQuery(['languages'], () =>
     apiClient.languages.findAll()


### PR DESCRIPTION
<!--
  Thank you for your PR! Please follow this template to help us review your PR quickly.
-->

## What has changed

When the translation view loads for each verse, it primes the cache with the next three verses if they haven't been loaded.

<!--
  Please name your PR following conventional commits.
  https://www.conventionalcommits.org/en/v1.0.0/
  The main ones to use are `feat`, `fix`, `chore`, `build`, `refactor`, and `docs`.

  If your PR is not connected to an issue, please describe the reason for your
  changes. Please also describe what you have changed. For more complex changes, include a self review that goes into more detail. Please also call attention to breaking changes, particularly in the shape of API routes.
-->

## Connected Issues

closes #186 

<!--
  If this PR resolves an issue, please add `closes #issue-no` below to connect the issue to the PR.
-->

## QA Steps

1. Start translating a verse
2. Click the next verse button
3. Confirm that there is no network latency when loading the next verse

<!-- Please describe how to test what you've changed. -->

## Post-Deployment

<!--
  Please describe any tasks that must be executed after this change is deployed.
-->

- [x] Nothing required
