### PR TITLE
refactor: cleaner gloss autocomplete input

### DIFF
--- a/packages/web/src/features/translation/TranslateWord.tsx
+++ b/packages/web/src/features/translation/TranslateWord.tsx
@@ -22,7 +22,6 @@ export interface TranslateWordProps {
   originalLanguage: 'hebrew' | 'greek';
   status: 'empty' | 'saving' | 'saved';
   onGlossChange(gloss?: string): void;
-  onKeyDown?: KeyboardEventHandler<HTMLElement>;
 }
 
 export interface TranslateWordRef {
@@ -40,7 +39,6 @@ const TranslateWord = forwardRef<TranslateWordRef, TranslateWordProps>(
       referenceGloss,
       previousGlosses,
       onGlossChange,
-      onKeyDown,
     }: TranslateWordProps,
     ref
   ) => {
@@ -48,6 +46,8 @@ const TranslateWord = forwardRef<TranslateWordRef, TranslateWordProps>(
     const [text, setText] = useState(gloss ?? '');
     const width = useTextWidth(text);
     const input = useRef<HTMLInputElement>(null);
+
+    const root = useRef<HTMLLIElement>(null);
 
     useImperativeHandle(
       ref,
@@ -58,7 +58,7 @@ const TranslateWord = forwardRef<TranslateWordRef, TranslateWordProps>(
     );
 
     return (
-      <li className="mx-2 mb-4">
+      <li className="mx-2 mb-4" ref={root}>
         <div
           id={`word-${word.id}`}
           className={`mb-2 ${
@@ -80,7 +80,6 @@ const TranslateWord = forwardRef<TranslateWordRef, TranslateWordProps>(
           <>
             <AutocompleteInput
               name="gloss"
-              className="min-w-[80px]"
               value={gloss}
               style={{ width: width + 24 }}
               aria-describedby={`word-help-${word.id}`}
@@ -92,8 +91,15 @@ const TranslateWord = forwardRef<TranslateWordRef, TranslateWordProps>(
                 }
               }}
               onKeyDown={(e) => {
-                if (onKeyDown) {
-                  onKeyDown(e);
+                if (e.metaKey || e.altKey || e.ctrlKey) return;
+                if (e.key === 'Enter') {
+                  if (e.shiftKey) {
+                    const prev = root.current?.previousElementSibling;
+                    prev?.querySelector('input')?.focus();
+                  } else {
+                    const prev = root.current?.nextElementSibling;
+                    prev?.querySelector('input')?.focus();
+                  }
                 }
               }}
               suggestions={previousGlosses}

--- a/packages/web/src/features/translation/TranslateWord.tsx
+++ b/packages/web/src/features/translation/TranslateWord.tsx
@@ -7,7 +7,7 @@ import {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Icon } from '../../shared/components/Icon';
-import AutocompleteInput from '../../shared/components/form/AutocompleteInput';
+import ComboboxInput from '../../shared/components/form/ComboboxInput';
 import InputHelpText from '../../shared/components/form/InputHelpText';
 import { useTextWidth } from '../../shared/hooks/useTextWidth';
 import { capitalize } from '../../shared/utils';
@@ -77,7 +77,7 @@ const TranslateWord = forwardRef<TranslateWordRef, TranslateWordProps>(
         </div>
         {editable && (
           <>
-            <AutocompleteInput
+            <ComboboxInput
               name="gloss"
               className="min-w-[80px]"
               value={gloss}

--- a/packages/web/src/features/translation/TranslateWord.tsx
+++ b/packages/web/src/features/translation/TranslateWord.tsx
@@ -85,10 +85,10 @@ const TranslateWord = forwardRef<TranslateWordRef, TranslateWordProps>(
               style={{ width: width + 24 }}
               aria-describedby={`word-help-${word.id}`}
               aria-labelledby={`word-${word.id}`}
-              onChange={(e) => {
-                if (e.target.value !== gloss) {
-                  onGlossChange(e.target.value);
-                  setText(e.target.value);
+              onChange={(value) => {
+                if (value !== gloss) {
+                  onGlossChange(value);
+                  setText(value);
                 }
               }}
               onKeyDown={(e) => {

--- a/packages/web/src/features/translation/TranslateWord.tsx
+++ b/packages/web/src/features/translation/TranslateWord.tsx
@@ -1,13 +1,6 @@
-import {
-  KeyboardEventHandler,
-  forwardRef,
-  useImperativeHandle,
-  useRef,
-  useState,
-} from 'react';
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Icon } from '../../shared/components/Icon';
-import ComboboxInput from '../../shared/components/form/ComboboxInput';
 import InputHelpText from '../../shared/components/form/InputHelpText';
 import { expandFontFamily } from '../../shared/hooks/useFontLoader';
 import { useTextWidth } from '../../shared/hooks/useTextWidth';
@@ -46,8 +39,11 @@ const TranslateWord = forwardRef<TranslateWordRef, TranslateWordProps>(
     ref
   ) => {
     const { t } = useTranslation(['translate']);
-    const [text, setText] = useState(gloss ?? '');
-    const width = useTextWidth(text);
+    const width = useTextWidth({
+      text: gloss ?? '',
+      fontFamily: expandFontFamily(font ?? 'Noto Sans'),
+      fontSize: '16px',
+    });
     const input = useRef<HTMLInputElement>(null);
 
     const root = useRef<HTMLLIElement>(null);
@@ -84,9 +80,9 @@ const TranslateWord = forwardRef<TranslateWordRef, TranslateWordProps>(
             <AutocompleteInput
               name="gloss"
               value={gloss}
-              // The extra 24 pixel give room for the padding around the text.
+              // The extra 42 pixels give room for the padding and caret icon.
               style={{
-                width: width + 24,
+                width: width + 42,
                 fontFamily: expandFontFamily(font ?? 'Noto Sans'),
               }}
               aria-describedby={`word-help-${word.id}`}
@@ -94,7 +90,6 @@ const TranslateWord = forwardRef<TranslateWordRef, TranslateWordProps>(
               onChange={(value) => {
                 if (value !== gloss) {
                   onGlossChange(value);
-                  setText(value);
                 }
               }}
               onKeyDown={(e) => {

--- a/packages/web/src/features/translation/TranslateWord.tsx
+++ b/packages/web/src/features/translation/TranslateWord.tsx
@@ -11,6 +11,7 @@ import ComboboxInput from '../../shared/components/form/ComboboxInput';
 import InputHelpText from '../../shared/components/form/InputHelpText';
 import { useTextWidth } from '../../shared/hooks/useTextWidth';
 import { capitalize } from '../../shared/utils';
+import AutocompleteInput from '../../shared/components/form/AutocompleteInput';
 
 export interface TranslateWordProps {
   editable?: boolean;
@@ -77,28 +78,17 @@ const TranslateWord = forwardRef<TranslateWordRef, TranslateWordProps>(
         </div>
         {editable && (
           <>
-            <ComboboxInput
+            <AutocompleteInput
               name="gloss"
               className="min-w-[80px]"
               value={gloss}
-              items={previousGlosses.map((gloss) => ({
-                label: gloss,
-                value: gloss,
-              }))}
-              // The extra 24 pixel give room for the padding around the text.
               style={{ width: width + 24 }}
               aria-describedby={`word-help-${word.id}`}
               aria-labelledby={`word-${word.id}`}
-              onChange={(newGloss: string) => {
-                if (newGloss !== gloss) {
-                  onGlossChange(newGloss);
-                  setText(newGloss);
-                }
-              }}
-              onCreate={(newGloss: string) => {
-                if (newGloss !== gloss) {
-                  onGlossChange(newGloss);
-                  setText(newGloss);
+              onChange={(e) => {
+                if (e.target.value !== gloss) {
+                  onGlossChange(e.target.value);
+                  setText(e.target.value);
                 }
               }}
               onKeyDown={(e) => {
@@ -106,6 +96,7 @@ const TranslateWord = forwardRef<TranslateWordRef, TranslateWordProps>(
                   onKeyDown(e);
                 }
               }}
+              suggestions={previousGlosses}
               ref={input}
             />
             <InputHelpText id={`word-help-${word.id}`}>

--- a/packages/web/src/features/translation/TranslationView.tsx
+++ b/packages/web/src/features/translation/TranslationView.tsx
@@ -286,7 +286,6 @@ export default function TranslationView() {
                         gloss: newGloss,
                       });
                     }}
-                    onKeyDown={handleKeyPress}
                     ref={(() => {
                       if (i === 0) {
                         return firstWord;

--- a/packages/web/src/shared/components/form/AutocompleteInput.tsx
+++ b/packages/web/src/shared/components/form/AutocompleteInput.tsx
@@ -1,0 +1,82 @@
+import { ComponentProps, forwardRef, useEffect, useState } from 'react';
+import { Icon } from '../Icon';
+
+export interface AutocompleteInputProps
+  extends Omit<ComponentProps<'input'>, 'value'> {
+  value?: string;
+  suggestions: string[];
+}
+
+function normalizeFilter(word: string) {
+  // From https://stackoverflow.com/a/37511463
+  return word.normalize('NFD').replace(/\p{Diacritic}/gu, '');
+}
+
+const AutocompleteInput = forwardRef<HTMLInputElement, AutocompleteInputProps>(
+  ({ className, onBlur, suggestions, value, ...props }, ref) => {
+    const [open, setOpen] = useState(false);
+    const [filteredSuggestions, setFilteredSuggestions] = useState<string[]>(
+      []
+    );
+
+    useEffect(() => {
+      if (value) {
+        const normalizedInput = normalizeFilter(value.toLowerCase());
+        setFilteredSuggestions(
+          suggestions.filter((suggestion) =>
+            normalizeFilter(suggestion.toLowerCase()).includes(normalizedInput)
+          )
+        );
+      } else {
+        setFilteredSuggestions(suggestions);
+      }
+    }, [value, suggestions]);
+
+    return (
+      <div className={`${className}  group/combobox relative`}>
+        <div
+          className={`
+            border rounded shadow-inner flex group-focus-within/combobox:outline group-focus-within/combobox:outline-2
+          border-slate-400 group-focus-within/combobox:outline-blue-600
+          `}
+        >
+          <input
+            ref={ref}
+            {...props}
+            value={value ?? ''}
+            onBlur={(e) => {
+              if (e.relatedTarget !== e.currentTarget.nextSibling) {
+                setOpen(false);
+              }
+              onBlur?.(e);
+            }}
+            className="w-full py-2 px-3 h-10 rounded-b flex-grow focus:outline-none bg-transparent rounded"
+          />
+          <button
+            className="w-8"
+            aria-hidden="true"
+            tabIndex={-1}
+            onClick={(e) => {
+              setOpen(!open);
+              const input = e.currentTarget.previousSibling as HTMLInputElement;
+              input.focus();
+            }}
+          >
+            <Icon icon={open ? 'caret-up' : 'caret-down'} />
+          </button>
+        </div>
+        {open && (
+          <ol className="z-10 absolute min-w-[160px] w-full max-h-80 bg-white overflow-auto mt-1 rounded border border-slate-400 shadow">
+            {filteredSuggestions.map((suggestion) => (
+              <li className="px-3 py-2 ui-active:bg-blue-400" key={suggestion}>
+                {suggestion}
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    );
+  }
+);
+
+export default AutocompleteInput;

--- a/packages/web/src/shared/components/form/AutocompleteInput.tsx
+++ b/packages/web/src/shared/components/form/AutocompleteInput.tsx
@@ -72,6 +72,7 @@ const AutocompleteInput = forwardRef<HTMLInputElement, AutocompleteInputProps>(
           <input
             ref={ref}
             {...props}
+            autoComplete="off"
             value={input}
             onChange={(e) => {
               open();
@@ -170,7 +171,7 @@ const AutocompleteInput = forwardRef<HTMLInputElement, AutocompleteInputProps>(
                     : undefined
                 }
                 className={`
-                  px-3 py-1 whitespace-nowrap
+                  px-3 py-1 whitespace-nowrap cursor-pointer hover:bg-blue-400
                   ${i === activeIndex ? 'bg-blue-400' : ''}
                 `}
                 key={suggestion}

--- a/packages/web/src/shared/components/form/AutocompleteInput.tsx
+++ b/packages/web/src/shared/components/form/AutocompleteInput.tsx
@@ -2,8 +2,9 @@ import { ComponentProps, forwardRef, useEffect, useState } from 'react';
 import { Icon } from '../Icon';
 
 export interface AutocompleteInputProps
-  extends Omit<ComponentProps<'input'>, 'value'> {
+  extends Omit<ComponentProps<'input'>, 'value' | 'onChange'> {
   value?: string;
+  onChange(value: string): void;
   suggestions: string[];
 }
 
@@ -13,11 +14,16 @@ function normalizeFilter(word: string) {
 }
 
 const AutocompleteInput = forwardRef<HTMLInputElement, AutocompleteInputProps>(
-  ({ className, onBlur, suggestions, value, ...props }, ref) => {
-    const [open, setOpen] = useState(false);
+  (
+    { className, onBlur, suggestions, value, onChange, onKeyDown, ...props },
+    ref
+  ) => {
+    const [isOpen, setOpen] = useState(false);
     const [filteredSuggestions, setFilteredSuggestions] = useState<string[]>(
       []
     );
+
+    const [activeIndex, setActiveIndex] = useState<number | undefined>();
 
     useEffect(() => {
       if (value) {
@@ -27,13 +33,25 @@ const AutocompleteInput = forwardRef<HTMLInputElement, AutocompleteInputProps>(
             normalizeFilter(suggestion.toLowerCase()).includes(normalizedInput)
           )
         );
+        setActiveIndex(undefined);
       } else {
         setFilteredSuggestions(suggestions);
+        setActiveIndex(undefined);
       }
     }, [value, suggestions]);
 
+    function open() {
+      setOpen(true);
+      setActiveIndex(undefined);
+    }
+
+    function close() {
+      setOpen(false);
+      setActiveIndex(undefined);
+    }
+
     return (
-      <div className={`${className}  group/combobox relative`}>
+      <div className={`${className} group/combobox relative`}>
         <div
           className={`
             border rounded shadow-inner flex group-focus-within/combobox:outline group-focus-within/combobox:outline-2
@@ -44,11 +62,71 @@ const AutocompleteInput = forwardRef<HTMLInputElement, AutocompleteInputProps>(
             ref={ref}
             {...props}
             value={value ?? ''}
+            onChange={(e) => {
+              open();
+              onChange(e.target.value);
+            }}
             onBlur={(e) => {
               if (e.relatedTarget !== e.currentTarget.nextSibling) {
-                setOpen(false);
+                close();
               }
               onBlur?.(e);
+            }}
+            onKeyDown={(e) => {
+              if (!e.altKey && !e.ctrlKey && !e.shiftKey && !e.metaKey) {
+                switch (e.key) {
+                  case 'Enter':
+                  case 'Tab': {
+                    if (typeof activeIndex === 'number') {
+                      onChange(filteredSuggestions[activeIndex]);
+                    }
+                    break;
+                  }
+                  case 'Escape': {
+                    close();
+                    e.preventDefault();
+                    e.stopPropagation();
+                    break;
+                  }
+                  case 'ArrowDown': {
+                    if (isOpen) {
+                      if (typeof activeIndex === 'number') {
+                        if (activeIndex === filteredSuggestions.length - 1) {
+                          setActiveIndex(undefined);
+                        } else {
+                          setActiveIndex(activeIndex + 1);
+                        }
+                      } else {
+                        setActiveIndex(0);
+                      }
+                    } else {
+                      open();
+                    }
+                    e.preventDefault();
+                    e.stopPropagation();
+                    break;
+                  }
+                  case 'ArrowUp': {
+                    if (isOpen) {
+                      if (typeof activeIndex === 'number') {
+                        if (activeIndex === 0) {
+                          setActiveIndex(undefined);
+                        } else {
+                          setActiveIndex(activeIndex - 1);
+                        }
+                      } else {
+                        setActiveIndex(filteredSuggestions.length - 1);
+                      }
+                    } else {
+                      open();
+                    }
+                    e.preventDefault();
+                    e.stopPropagation();
+                    break;
+                  }
+                }
+              }
+              onKeyDown?.(e);
             }}
             className="w-full py-2 px-3 h-10 rounded-b flex-grow focus:outline-none bg-transparent rounded"
           />
@@ -57,18 +135,25 @@ const AutocompleteInput = forwardRef<HTMLInputElement, AutocompleteInputProps>(
             aria-hidden="true"
             tabIndex={-1}
             onClick={(e) => {
-              setOpen(!open);
+              if (isOpen) close();
+              else open();
               const input = e.currentTarget.previousSibling as HTMLInputElement;
               input.focus();
             }}
           >
-            <Icon icon={open ? 'caret-up' : 'caret-down'} />
+            <Icon icon={isOpen ? 'caret-up' : 'caret-down'} />
           </button>
         </div>
-        {open && (
-          <ol className="z-10 absolute min-w-[160px] w-full max-h-80 bg-white overflow-auto mt-1 rounded border border-slate-400 shadow">
-            {filteredSuggestions.map((suggestion) => (
-              <li className="px-3 py-2 ui-active:bg-blue-400" key={suggestion}>
+        {isOpen && (
+          <ol className="z-10 absolute min-w-full max-h-80 bg-white overflow-auto mt-1 rounded border border-slate-400 shadow">
+            {filteredSuggestions.map((suggestion, i) => (
+              <li
+                className={`
+                  px-3 py-2
+                  ${i === activeIndex ? 'bg-blue-400' : ''}
+                `}
+                key={suggestion}
+              >
                 {suggestion}
               </li>
             ))}

--- a/packages/web/src/shared/components/form/AutocompleteInput.tsx
+++ b/packages/web/src/shared/components/form/AutocompleteInput.tsx
@@ -15,7 +15,16 @@ function normalizeFilter(word: string) {
 
 const AutocompleteInput = forwardRef<HTMLInputElement, AutocompleteInputProps>(
   (
-    { className, onBlur, suggestions, value, onChange, onKeyDown, ...props },
+    {
+      className,
+      style,
+      onBlur,
+      suggestions,
+      value,
+      onChange,
+      onKeyDown,
+      ...props
+    },
     ref
   ) => {
     const [input, setInput] = useState('');
@@ -62,7 +71,7 @@ const AutocompleteInput = forwardRef<HTMLInputElement, AutocompleteInputProps>(
     }
 
     return (
-      <div className={`${className} group/combobox relative`}>
+      <div className={`${className} group/combobox relative`} style={style}>
         <div
           className={`
             border rounded shadow-inner flex group-focus-within/combobox:outline group-focus-within/combobox:outline-2
@@ -70,8 +79,9 @@ const AutocompleteInput = forwardRef<HTMLInputElement, AutocompleteInputProps>(
           `}
         >
           <input
-            ref={ref}
             {...props}
+            ref={ref}
+            className="w-full py-2 ps-3 h-10 rounded-b flex-grow focus:outline-none bg-transparent rounded"
             autoComplete="off"
             value={input}
             onChange={(e) => {
@@ -79,7 +89,11 @@ const AutocompleteInput = forwardRef<HTMLInputElement, AutocompleteInputProps>(
               setInput(e.target.value);
             }}
             onBlur={(e) => {
-              if (e.relatedTarget !== e.currentTarget.nextSibling) {
+              if (
+                !e.currentTarget.parentElement?.parentElement?.contains(
+                  e.relatedTarget
+                )
+              ) {
                 close();
                 change(input);
               }
@@ -141,7 +155,6 @@ const AutocompleteInput = forwardRef<HTMLInputElement, AutocompleteInputProps>(
               }
               onKeyDown?.(e);
             }}
-            className="w-full py-2 px-3 h-10 rounded-b flex-grow focus:outline-none bg-transparent rounded"
           />
           <button
             className="w-8"
@@ -161,6 +174,7 @@ const AutocompleteInput = forwardRef<HTMLInputElement, AutocompleteInputProps>(
           <ol className="z-10 absolute min-w-full max-h-80 bg-white overflow-auto mt-1 rounded border border-slate-400 shadow">
             {filteredSuggestions.map((suggestion, i) => (
               <li
+                tabIndex={-1}
                 ref={
                   i === activeIndex
                     ? (el) => {

--- a/packages/web/src/shared/components/form/ComboboxInput.tsx
+++ b/packages/web/src/shared/components/form/ComboboxInput.tsx
@@ -10,26 +10,26 @@ import { Icon } from '../Icon';
 
 const CREATE_TAG = '_create';
 
-export interface AutocompleteItem {
+export interface ComboboxItem {
   label: string;
   value: string;
 }
 
-export interface AutocompleteProps
+export interface ComboboxProps
   extends Omit<ComponentProps<'input'>, 'value' | 'onChange' | 'ref'> {
   className?: string;
   value?: string;
   onBlur?(): void;
   onChange?(value: string): void;
   onCreate?(text?: string): void;
-  items: AutocompleteItem[];
+  items: ComboboxItem[];
   defaultValue?: string[];
   name: string;
   hasErrors?: boolean;
   onKeyDown?: KeyboardEventHandler<HTMLInputElement>;
 }
 
-const AutocompleteInput = forwardRef<HTMLInputElement, AutocompleteProps>(
+const ComboboxInput = forwardRef<HTMLInputElement, ComboboxProps>(
   (
     {
       className = '',
@@ -42,12 +42,11 @@ const AutocompleteInput = forwardRef<HTMLInputElement, AutocompleteProps>(
       name,
       onKeyDown,
       ...props
-    }: AutocompleteProps,
+    }: ComboboxProps,
     ref
   ) => {
     const [normalizedInputValue, setNormalizedInputValue] = useState('');
-    const [filteredItems, setFilteredItems] =
-      useState<AutocompleteItem[]>(items);
+    const [filteredItems, setFilteredItems] = useState<ComboboxItem[]>(items);
 
     // If none of the items matches the input value exactly,
     // then we want to give the option of creating a new item.
@@ -85,15 +84,15 @@ const AutocompleteInput = forwardRef<HTMLInputElement, AutocompleteProps>(
     }
 
     return (
-      <div className={`${className}  group/autocomplete relative`}>
+      <div className={`${className}  group/combobox relative`}>
         <Combobox value={value} onChange={onComboboxChange} name={name}>
           <div
-            className={`border rounded shadow-inner flex group-focus-within/autocomplete:outline group-focus-within/autocomplete:outline-2
+            className={`border rounded shadow-inner flex group-focus-within/combobox:outline group-focus-within/combobox:outline-2
 
             ${
               hasErrors
-                ? 'border-red-700 shadow-red-100 group-focus-within/autocomplete:outline-red-700'
-                : 'border-slate-400 group-focus-within/autocomplete:outline-blue-600'
+                ? 'border-red-700 shadow-red-100 group-focus-within/combobox:outline-red-700'
+                : 'border-slate-400 group-focus-within/combobox:outline-blue-600'
             }
           `}
           >
@@ -147,4 +146,4 @@ function ignoreDiacritics(word: string) {
   return word.normalize('NFD').replace(/\p{Diacritic}/gu, '');
 }
 
-export default AutocompleteInput;
+export default ComboboxInput;

--- a/packages/web/src/shared/hooks/useTextWidth.ts
+++ b/packages/web/src/shared/hooks/useTextWidth.ts
@@ -1,16 +1,22 @@
-import { useEffect, useRef, useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
+
+export interface UseTextWidthOptions {
+  /** The text to measure */
+  text: string;
+  /** The font family to measure the text in. */
+  fontFamily: string;
+  /** The font size to measure the text in. */
+  fontSize: string;
+}
 
 /**
  * Calculate the width of some text.
- * @param text The text to measure.
  * @returns The width of the text, in pixels.
  */
-// TODO: allow the font information to be passed in, so that we can take
-//       into account things like font family, font size, and font weight.
-export function useTextWidth(text: string): number {
+export function useTextWidth(options: UseTextWidthOptions): number {
   const el = useRef<HTMLDivElement>();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const div = document.createElement('div');
     div.style.width = 'auto';
     div.style.height = '0';
@@ -28,12 +34,14 @@ export function useTextWidth(text: string): number {
 
   const [width, setWidth] = useState(0);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (el.current) {
-      el.current.innerText = text;
+      el.current.style.fontFamily = options.fontFamily;
+      el.current.style.fontSize = options.fontSize;
+      el.current.innerText = options.text;
       setWidth(el.current.clientWidth);
     }
-  }, [text]);
+  }, [options]);
 
   return width;
 }


### PR DESCRIPTION
<!--
  Thank you for your PR! Please follow this template to help us review your PR quickly.
-->

## What has changed

* Current autocomplete input is renamed to be combobox input
* Autocomplete input is rebuilt to work more like a textbox with suggestions, similar to how search autocomplete works in most websites
* Additionally, the enter key will move between glosses. In future work, the enter key will be used for approval

<!--
  Please name your PR following conventional commits.
  https://www.conventionalcommits.org/en/v1.0.0/
  The main ones to use are `feat`, `fix`, `chore`, `build`, `refactor`, and `docs`.

  If your PR is not connected to an issue, please describe the reason for your
  changes. Please also describe what you have changed. For more complex changes, include a self review that goes into more detail. Please also call attention to breaking changes, particularly in the shape of API routes.
-->

## Connected Issues

closes #183, closes #182

<!--
  If this PR resolves an issue, please add `closes #issue-no` below to connect the issue to the PR.
-->

## QA Steps

<!-- Please describe how to test what you've changed. -->

1. Verify that if you type something in the textbox, the tab and enter keys will always save that entry
2. Verify that an option is not highlighted until you use the arrow keys
3. Verify that when an option is highlighted, tab and enter select that value
4. Verify that typing filters the list and removes the item highlight

## Post-Deployment

<!--
  Please describe any tasks that must be executed after this change is deployed.
-->

- [x] Nothing required
