### PR TITLE
refactor: refetch gloss suggestions when verse loads

### DIFF
--- a/packages/web/src/features/translation/TranslationView.tsx
+++ b/packages/web/src/features/translation/TranslationView.tsx
@@ -54,22 +54,29 @@ function useTranslationQueries(language: string, verseId: string) {
     let nextVerseId = verseId;
     for (let i = 0; i < VERSES_TO_PREFETCH; i++) {
       nextVerseId = incrementVerseId(nextVerseId);
-      queryClient.ensureQueryData({
+      queryClient.prefetchQuery({
         queryKey: ['verse', nextVerseId],
         queryFn: ({ queryKey }) => apiClient.verses.findById(queryKey[1]),
       });
-      queryClient.ensureQueryData({
+      queryClient.prefetchQuery({
         queryKey: ['verse-glosses', 'eng', nextVerseId],
         queryFn: ({ queryKey }) =>
           apiClient.verses.findVerseGlosses(queryKey[2], 'eng'),
       });
-      queryClient.ensureQueryData({
+      queryClient.prefetchQuery({
         queryKey: ['verse-glosses', language, nextVerseId],
         queryFn: ({ queryKey }) =>
           apiClient.verses.findVerseGlosses(queryKey[2], queryKey[1]),
       });
     }
   }, [language, verseId, queryClient]);
+
+  // This ensures that when the verse changes, we have the latest gloss suggestions,
+  // but in the meantime, we can show what was prefetched.
+  const refetch = targetGlossesQuery.refetch;
+  useEffect(() => {
+    refetch();
+  }, [refetch, language, verseId]);
 
   return {
     languagesQuery,


### PR DESCRIPTION
<!--
  Thank you for your PR! Please follow this template to help us review your PR quickly.
-->

## What has changed

When a new verse loads, use the suggestions that were prefetched, but also load the latest data from the server. This turned out to be pretty easy with react-query

<!--
  Please name your PR following conventional commits.
  https://www.conventionalcommits.org/en/v1.0.0/
  The main ones to use are `feat`, `fix`, `chore`, `build`, `refactor`, and `docs`.

  If your PR is not connected to an issue, please describe the reason for your
  changes. Please also describe what you have changed. For more complex changes, include a self review that goes into more detail. Please also call attention to breaking changes, particularly in the shape of API routes.
-->

## Connected Issues

closes #226 

<!--
  If this PR resolves an issue, please add `closes #issue-no` below to connect the issue to the PR.
-->

## QA Steps

<!-- Please describe how to test what you've changed. -->

1. Load a verse in the translator view
2. Navigate to the next verse
3. Check the network tools for a request for the latest gloss data

## Post-Deployment

<!--
  Please describe any tasks that must be executed after this change is deployed.
-->

- [x] Nothing required
