### PR TITLE
fix: populate preview font default value

### DIFF
--- a/packages/web/src/features/languages/ManageLanguageView.tsx
+++ b/packages/web/src/features/languages/ManageLanguageView.tsx
@@ -191,7 +191,7 @@ export default function ManageLanguageView() {
               name="font"
               className="w-full h-10"
               required
-              value={previewFont}
+              defaultValue={previewFont}
               items={fonts.map((font) => ({ label: font, value: font }))}
               onChange={(font) => setPreviewFont(font)}
             />


### PR DESCRIPTION
<!--
  Thank you for your PR! Please follow this template to help us review your PR quickly.
-->

## What has changed

<!--
  Please name your PR following conventional commits.
  https://www.conventionalcommits.org/en/v1.0.0/
  The main ones to use are `feat`, `fix`, `chore`, `build`, `refactor`, and `docs`.

  If your PR is not connected to an issue, please describe the reason for your
  changes. Please also describe what you have changed. For more complex changes, include a self review that goes into more detail. Please also call attention to breaking changes, particularly in the shape of API routes.
-->

Use `defaultValue` instead of `value` for the font selector input.

## Connected Issues

<!--
  If this PR resolves an issue, please add `closes #issue-no` below to connect the issue to the PR.
-->
Closes #236 

## QA Steps

<!-- Please describe how to test what you've changed. -->

1. Go to the manage language page for a language.
2. Select a font.
3. Click "Update"
4. Refresh the browser.
    - The selected font should be persisted in the font selector.

## Post-Deployment

<!--
  Please describe any tasks that must be executed after this change is deployed.
-->

- [ ] Nothing required
