### PR TITLE
fix: next button arrow

### DIFF
--- a/packages/web/src/features/translation/TranslationView.tsx
+++ b/packages/web/src/features/translation/TranslationView.tsx
@@ -416,13 +416,13 @@ export default function TranslationView() {
                         );
                       }}
                     >
-                      {isHebrew && <Icon icon="arrow-left" className="mr-1" />}
                       <span dir={i18n.dir(i18n.language)}>
                         {t('common:next')}
                       </span>
-                      {!isHebrew && (
-                        <Icon icon="arrow-right" className="ml-1" />
-                      )}
+                      <Icon
+                        icon={isHebrew ? 'arrow-left' : 'arrow-right'}
+                        className="ms-1"
+                      />
                     </Button>
                   </li>
                 )}


### PR DESCRIPTION
<!--
  Thank you for your PR! Please follow this template to help us review your PR quickly.
-->

## What has changed

In hebrew, the arrow in the next button was in the wrong place. I think this should fix that.

<!--
  Please name your PR following conventional commits.
  https://www.conventionalcommits.org/en/v1.0.0/
  The main ones to use are `feat`, `fix`, `chore`, `build`, `refactor`, and `docs`.

  If your PR is not connected to an issue, please describe the reason for your
  changes. Please also describe what you have changed. For more complex changes, include a self review that goes into more detail. Please also call attention to breaking changes, particularly in the shape of API routes.
-->


## QA Steps

<!-- Please describe how to test what you've changed. -->

Look at the next button at the end of the translation line for Genesis and Matthew in English and Arabic interface languages. The arrow should point right for greek and left of hebrew regardless of interface language.

## Post-Deployment

<!--
  Please describe any tasks that must be executed after this change is deployed.
-->

- [x] Nothing required
