### PR TITLE
fix: clean up brackets in the LSJ data

### DIFF
--- a/packages/db/src/scripts/helpers/import-lexicon.ts
+++ b/packages/db/src/scripts/helpers/import-lexicon.ts
@@ -11,7 +11,6 @@ export const importLexicon = async (
   console.log(`Importing ${resourceCode} definitions...`);
   const parsed = await parseLexicon(filename, [definitionField]);
   console.log(`Parsed ${Object.keys(parsed).length} words`);
-  console.log(JSON.stringify(Object.keys(parsed), null, 2));
   await client.lemmaResource.deleteMany({ where: { resourceCode } });
   const lemmaData: Lemma[] = [];
   const resourceData: LemmaResource[] = [];

--- a/packages/db/src/scripts/helpers/parse-lexicon.ts
+++ b/packages/db/src/scripts/helpers/parse-lexicon.ts
@@ -59,7 +59,8 @@ const toMarkDown = (raw: string): string => {
     .replaceAll(/<ref=".*">/g, '')
     .replaceAll(/<ref='.*'>/g, '')
     .replaceAll('</ref>', '')
-    .replaceAll(/<a.*>/g, '')
+    .replaceAll(/\[?<a[^>]*>/g, '')
+    .replaceAll('</a>]', '')
     .replaceAll('</a>', '')
     .replaceAll('<u>', '') // Markdown doesn't have underline
     .replaceAll('</u>', '')

--- a/packages/db/src/scripts/import-bible.ts
+++ b/packages/db/src/scripts/import-bible.ts
@@ -64,10 +64,9 @@ async function run() {
 
           // We clean the strongs codes since the hebrew ones have some extra characters.
           // We also prefix the code with a language code based on the book.
-          const strongs = `${book.id < 40 ? 'H' : 'G'}${rawStrongs.replace(
-            STRONGS_REGEX,
-            ''
-          )}`;
+          const strongs = `${book.id < 40 ? 'H' : 'G'}${rawStrongs
+            .replace(STRONGS_REGEX, '')
+            .padStart(4, '0')}`;
 
           // We have to accumulate word data until we have inserted all of the lemma data.
           const wordId = `${verseId}${(wordIndex + 1)
@@ -98,7 +97,7 @@ async function run() {
           forms: {
             createMany: {
               data: Object.keys(forms).map((grammar, i) => {
-                const id = `${lemma}-${i + 1}`;
+                const id = `${lemma}-${(i + 1).toString().padStart(3, '0')}`;
                 lemmas[lemma][grammar].formId = id;
                 return {
                   id,

--- a/packages/db/src/scripts/import-strongs.ts
+++ b/packages/db/src/scripts/import-strongs.ts
@@ -1,11 +1,16 @@
-import { Lemma, LemmaResource, PrismaClient } from '@prisma/client';
+import {
+  Lemma,
+  LemmaResource,
+  PrismaClient,
+  ResourceCode,
+} from '@prisma/client';
 import { greekStrongsData, hebrewStrongsData } from '../../../../data/strongs';
 
 const client = new PrismaClient();
 
 const importStrongs = async () => {
   await client.lemmaResource.deleteMany({
-    where: { resourceCode: 'STRONGS' as const },
+    where: { resourceCode: ResourceCode.STRONGS },
   });
   console.log('Importing hebrew strongs definitions...');
   await importStrongsData(hebrewStrongsData);
@@ -30,9 +35,16 @@ const importStrongsData = async (
       return true;
     })
     .forEach((lemmaId) => {
-      lemmaData.push({ id: lemmaId });
+      const normalizedId = `${lemmaId[0]}${lemmaId
+        .substring(1)
+        .padStart(4, '0')}`;
+      lemmaData.push({ id: normalizedId });
       const content = data[lemmaId]['strongs_def'];
-      resourceData.push({ lemmaId, resourceCode: 'STRONGS' as const, content });
+      resourceData.push({
+        lemmaId: normalizedId,
+        resourceCode: ResourceCode.STRONGS,
+        content,
+      });
     });
   // We have to create non-existent lemmas, so that the foreign key on lemma
   // resources has something to point to.


### PR DESCRIPTION
<!--
  Thank you for your PR! Please follow this template to help us review your PR quickly.
-->

## What has changed

<!--
  Please name your PR following conventional commits.
  https://www.conventionalcommits.org/en/v1.0.0/
  The main ones to use are `feat`, `fix`, `chore`, `build`, `refactor`, and `docs`.

  If your PR is not connected to an issue, please describe the reason for your
  changes. Please also describe what you have changed. For more complex changes, include a self review that goes into more detail. Please also call attention to breaking changes, particularly in the shape of API routes.
-->

Cleaned up the leftover `[]` that were incorrectly left in the LSJ data.

## Connected Issues

<!--
  If this PR resolves an issue, please add `closes #issue-no` below to connect the issue to the PR.
-->

#262 

## QA Steps

<!-- Please describe how to test what you've changed. -->
- [ ] Run `nx run db:import-lsj`
- [ ] Run `SELECT * FROM "LemmaResource" WHERE "resourceCode" = 'LSJ';` in your database
     - There should NOT be extra `[]` in the results

## Post-Deployment

<!--
  Please describe any tasks that must be executed after this change is deployed.
-->

- [ ] Run `nx run db:import-lsj` in the production DB
