### PR TITLE
refactor: revoke language admin permissions to manage users

### DIFF
--- a/packages/api/pages/api/languages/[code]/members/[userId].ts
+++ b/packages/api/pages/api/languages/[code]/members/[userId].ts
@@ -16,7 +16,7 @@ export default createRoute<{ code: string; userId: string }>()
       ),
     }),
     authorize: authorize((req) => ({
-      action: 'administer',
+      action: 'administer-members',
       subject: 'Language',
       subjectId: req.query.code,
     })),
@@ -62,7 +62,7 @@ export default createRoute<{ code: string; userId: string }>()
   })
   .delete<void, void>({
     authorize: authorize((req) => ({
-      action: 'administer',
+      action: 'administer-members',
       subject: 'Language',
       subjectId: req.query.code,
     })),

--- a/packages/api/pages/api/languages/[code]/members/index.ts
+++ b/packages/api/pages/api/languages/[code]/members/index.ts
@@ -70,7 +70,7 @@ export default createRoute<{ code: string }>()
   })
   .post<PostLanguageMemberRequestBody, void>({
     authorize: authorize((req) => ({
-      action: 'administer',
+      action: 'administer-members',
       subject: 'Language',
       subjectId: req.query.code,
     })),

--- a/packages/api/shared/access-control/policy.ts
+++ b/packages/api/shared/access-control/policy.ts
@@ -8,7 +8,13 @@ export type Subject = Subjects<{
   AuthUser: AuthUser;
 }>;
 export type RawSubject = Extract<Subject, string>;
-export type Action = 'create' | 'read' | 'translate' | 'administer' | 'update';
+export type Action =
+  | 'create'
+  | 'read'
+  | 'translate'
+  | 'administer'
+  | 'update'
+  | 'administer-members';
 
 export type Policy = PureAbility<[Action, Subject], PrismaQuery>;
 
@@ -53,6 +59,7 @@ export function createPolicyFor(user?: Actor) {
       can('create', 'Language');
       can('read', 'Language');
       can('administer', 'Language');
+      can('administer-members', 'Language');
 
       can('create', 'AuthUser');
       can('read', 'AuthUser');

--- a/packages/web/src/shared/accessControl.tsx
+++ b/packages/web/src/shared/accessControl.tsx
@@ -14,7 +14,12 @@ interface Actor {
   }[];
 }
 
-export type Action = 'create' | 'read' | 'translate' | 'administer';
+export type Action =
+  | 'create'
+  | 'read'
+  | 'translate'
+  | 'administer'
+  | 'administer-members';
 export type SubjectType = 'User' | 'Language';
 export type Subject = SubjectType | { id: string };
 export type Policy = PureAbility<[Action, Subject]>;
@@ -58,6 +63,7 @@ export function createPolicyFor(user?: Actor) {
       can('create', 'Language');
       can('read', 'Language');
       can('administer', 'Language');
+      can('administer-members', 'Language');
 
       can('create', 'User');
       can('read', 'User');


### PR DESCRIPTION
<!--
  Thank you for your PR! Please follow this template to help us review your PR quickly.
-->

## What has changed

Language admins can no longer add, remove, or modify language members.

<!--
  Please name your PR following conventional commits.
  https://www.conventionalcommits.org/en/v1.0.0/
  The main ones to use are `feat`, `fix`, `chore`, `build`, `refactor`, and `docs`.

  If your PR is not connected to an issue, please describe the reason for your
  changes. Please also describe what you have changed. For more complex changes, include a self review that goes into more detail. Please also call attention to breaking changes, particularly in the shape of API routes.
-->

## Connected Issues

closes #274 

<!--
  If this PR resolves an issue, please add `closes #issue-no` below to connect the issue to the PR.
-->

## QA Steps

<!-- Please describe how to test what you've changed. -->

1. Add a new member to a language and make them an admin on that language
2. Log in as that user
3. Confirm that language member table has no controls to edit users

## Post-Deployment

<!--
  Please describe any tasks that must be executed after this change is deployed.
-->

- [x] Nothing required
