### PR TITLE
fix: import hebrew words without strongs numbers

### DIFF
--- a/packages/db/src/scripts/import-bible.ts
+++ b/packages/db/src/scripts/import-bible.ts
@@ -55,12 +55,9 @@ async function run() {
           },
         });
 
-        // Some entries in the words list are text in between words, so we ignore them.
-        const filteredWords = words.filter((word) => word.length === 6);
-
-        for (let wordIndex = 0; wordIndex < filteredWords.length; wordIndex++) {
-          const [text, , english, grammar, rawStrongs] =
-            filteredWords[wordIndex];
+        for (let wordIndex = 0; wordIndex < words.length; wordIndex++) {
+          const [text, , english, grammar = '', rawStrongs = '????'] =
+            words[wordIndex];
 
           // We clean the strongs codes since the hebrew ones have some extra characters.
           // We also prefix the code with a language code based on the book.


### PR DESCRIPTION
<!--
  Thank you for your PR! Please follow this template to help us review your PR quickly.
-->

## What has changed

Previously, we were only using words in Sheldon's dataset that had 6 entries, but this excludes some words in the Hebrew text that don't have strongs numbers. This PR removes that filter, and updates the data seed.

I didn't bother to readd any of the lexicons back to the seed since those are still in flux.

<!--
  Please name your PR following conventional commits.
  https://www.conventionalcommits.org/en/v1.0.0/
  The main ones to use are `feat`, `fix`, `chore`, `build`, `refactor`, and `docs`.

  If your PR is not connected to an issue, please describe the reason for your
  changes. Please also describe what you have changed. For more complex changes, include a self review that goes into more detail. Please also call attention to breaking changes, particularly in the shape of API routes.
-->

## Connected Issues

closes #285 

<!--
  If this PR resolves an issue, please add `closes #issue-no` below to connect the issue to the PR.
-->

## QA Steps

<!-- Please describe how to test what you've changed. -->

Import the seed and check Obadiah 5 for correctness.

## Post-Deployment

<!--
  Please describe any tasks that must be executed after this change is deployed.
-->

I've already updated the data in production
