### PR TITLE
refactor: simplify form abstractions

### DIFF
--- a/packages/web/src/app/LanguageDialog.tsx
+++ b/packages/web/src/app/LanguageDialog.tsx
@@ -16,7 +16,6 @@ const LanguageDialog = forwardRef<DialogRef>((_, ref) => {
       </h1>
 
       <ComboboxInput
-        name="languages:language"
         className="block min-w-[150px]"
         value={i18n.resolvedLanguage}
         onChange={(language) => i18n.changeLanguage(language)}

--- a/packages/web/src/features/languages/ImportLanguageGlossesView.tsx
+++ b/packages/web/src/features/languages/ImportLanguageGlossesView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
 import { LoaderFunctionArgs, useLoaderData } from 'react-router-dom';
 import apiClient from '../../shared/apiClient';
@@ -185,17 +185,22 @@ export default function ImportLanguageGlossesView() {
                         <FormLabel htmlFor="import">
                           {t('languages:import_language').toUpperCase()}
                         </FormLabel>
-                        <ComboboxInput
-                          id="import"
+                        <Controller
                           name="import"
-                          className="w-full"
-                          autoComplete="off"
-                          required
-                          aria-describedby="import-error"
-                          items={importLanguages.data.map((language) => ({
-                            label: language,
-                            value: language,
-                          }))}
+                          rules={{ required: true }}
+                          render={({ field }) => (
+                            <ComboboxInput
+                              {...field}
+                              id="import"
+                              className="w-full"
+                              autoComplete="off"
+                              aria-describedby="import-error"
+                              items={importLanguages.data.map((language) => ({
+                                label: language,
+                                value: language,
+                              }))}
+                            />
+                          )}
                         />
                       </div>
                       <div>

--- a/packages/web/src/features/languages/InviteLanguageMemberView.tsx
+++ b/packages/web/src/features/languages/InviteLanguageMemberView.tsx
@@ -63,12 +63,13 @@ export default function InviteLanguageMemberView() {
               {t('users:email').toUpperCase()}
             </FormLabel>
             <TextInput
+              {...formContext.register('email', {
+                required: true,
+              })}
               id="email"
               type="email"
-              name="email"
               className="w-full"
               autoComplete="off"
-              required
               aria-describedby="email-error"
             />
             <InputError

--- a/packages/web/src/features/languages/InviteLanguageMemberView.tsx
+++ b/packages/web/src/features/languages/InviteLanguageMemberView.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { ApiClientError } from '@translation/api-client';
 import Form from '../../shared/components/form/Form';
 import InputError from '../../shared/components/form/InputError';
-import { useForm } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 import SubmittingIndicator from '../../shared/components/form/SubmittingIndicator';
 import Button from '../../shared/components/actions/Button';
 import { useFlash } from '../../shared/hooks/flash';
@@ -28,7 +28,11 @@ export default function InviteLanguageMemberView() {
   const flash = useFlash();
   const { t } = useTranslation(['users']);
 
-  const formContext = useForm<FormData>();
+  const formContext = useForm<FormData>({
+    defaultValues: {
+      roles: [LanguageRole.Translator],
+    },
+  });
   async function onSubmit(data: FormData) {
     try {
       await apiClient.languages.inviteMember(code, {
@@ -82,17 +86,21 @@ export default function InviteLanguageMemberView() {
             <FormLabel htmlFor="roles">
               {t('users:role', { count: 100 }).toUpperCase()}
             </FormLabel>
-            <MultiselectInput
-              className="w-full"
+            <Controller
               name="roles"
-              defaultValue={[LanguageRole.Translator]}
-              items={[
-                { label: t('users:role_admin'), value: LanguageRole.Admin },
-                {
-                  label: t('users:role_translator'),
-                  value: LanguageRole.Translator,
-                },
-              ]}
+              render={({ field }) => (
+                <MultiselectInput
+                  {...field}
+                  className="w-full"
+                  items={[
+                    { label: t('users:role_admin'), value: LanguageRole.Admin },
+                    {
+                      label: t('users:role_translator'),
+                      value: LanguageRole.Translator,
+                    },
+                  ]}
+                />
+              )}
             />
           </div>
           <div>

--- a/packages/web/src/features/languages/ManageLanguageView.tsx
+++ b/packages/web/src/features/languages/ManageLanguageView.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { LanguageRole, TextDirection } from '@translation/api-types';
 import { useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useLoaderData, useParams } from 'react-router-dom';
 import apiClient from '../../shared/apiClient';
@@ -141,6 +141,7 @@ export default function ManageLanguageView() {
   const formContext = useForm<FormData>({
     defaultValues: {
       name: language.data.name,
+      font: language.data.font,
     },
   });
   async function onSubmit(data: FormData) {
@@ -156,8 +157,6 @@ export default function ManageLanguageView() {
       flash.error(`${error}`);
     }
   }
-
-  const [previewFont, setPreviewFont] = useState(language.data.font);
 
   return (
     <View fitToScreen className="flex justify-center items-start">
@@ -191,14 +190,17 @@ export default function ManageLanguageView() {
             <FormLabel htmlFor="font">
               {t('languages:font').toUpperCase()}
             </FormLabel>
-            <ComboboxInput
-              id="font"
+            <Controller
               name="font"
-              className="w-full h-10"
-              required
-              defaultValue={previewFont}
-              items={fonts.map((font) => ({ label: font, value: font }))}
-              onChange={(font) => setPreviewFont(font)}
+              rules={{ required: true }}
+              render={({ field }) => (
+                <ComboboxInput
+                  {...field}
+                  id="font"
+                  className="w-full h-10"
+                  items={fonts.map((font) => ({ label: font, value: font }))}
+                />
+              )}
             />
           </div>
           <div className="mb-2">

--- a/packages/web/src/features/languages/ManageLanguageView.tsx
+++ b/packages/web/src/features/languages/ManageLanguageView.tsx
@@ -138,7 +138,11 @@ export default function ManageLanguageView() {
   const removeMemberMutation = useRemoveLanguageMemberMutation();
   const updateMemberMutation = useUpdateLanguageMemberMutation();
 
-  const formContext = useForm<FormData>();
+  const formContext = useForm<FormData>({
+    defaultValues: {
+      name: language.data.name,
+    },
+  });
   async function onSubmit(data: FormData) {
     try {
       await apiClient.languages.update(language.data.code, {
@@ -169,12 +173,12 @@ export default function ManageLanguageView() {
               {t('common:name').toUpperCase()}
             </FormLabel>
             <TextInput
+              {...formContext.register('name', {
+                required: true,
+              })}
               id="name"
-              name="name"
               className="w-full"
               autoComplete="off"
-              defaultValue={language.data.name}
-              required
               aria-describedby="name-error"
             />
             <InputError

--- a/packages/web/src/features/languages/ManageLanguageView.tsx
+++ b/packages/web/src/features/languages/ManageLanguageView.tsx
@@ -142,6 +142,8 @@ export default function ManageLanguageView() {
     defaultValues: {
       name: language.data.name,
       font: language.data.font,
+      textDirection: language.data.textDirection,
+      bibleTranslationIds: language.data.bibleTranslationIds,
     },
   });
   async function onSubmit(data: FormData) {
@@ -208,30 +210,39 @@ export default function ManageLanguageView() {
               {t('languages:text_direction').toUpperCase()}
             </FormLabel>
             <div>
-              <ButtonSelectorInput
+              <Controller
                 name="textDirection"
-                aria-labelledby="text-direction-label"
-                defaultValue={language.data.textDirection}
-              >
-                <ButtonSelectorOption value={TextDirection.LTR}>
-                  {t('languages:ltr')}
-                </ButtonSelectorOption>
-                <ButtonSelectorOption value={TextDirection.RTL}>
-                  {t('languages:rtl')}
-                </ButtonSelectorOption>
-              </ButtonSelectorInput>
+                rules={{ required: true }}
+                render={({ field }) => (
+                  <ButtonSelectorInput
+                    {...field}
+                    aria-labelledby="text-direction-label"
+                  >
+                    <ButtonSelectorOption value={TextDirection.LTR}>
+                      {t('languages:ltr')}
+                    </ButtonSelectorOption>
+                    <ButtonSelectorOption value={TextDirection.RTL}>
+                      {t('languages:rtl')}
+                    </ButtonSelectorOption>
+                  </ButtonSelectorInput>
+                )}
+              />
             </div>
           </div>
           <div className="mb-2">
             <FormLabel htmlFor="bibleTranslationIds">
               {t('languages:bible_translations').toUpperCase()}
             </FormLabel>
-            <SortableMultiselectInput
+            <Controller
               name="bibleTranslationIds"
-              className="w-full"
-              defaultValue={language.data.bibleTranslationIds}
-              items={translationOptions}
-              placeholder={t('languages:select_translations').toString()}
+              render={({ field }) => (
+                <SortableMultiselectInput
+                  {...field}
+                  className="w-full"
+                  items={translationOptions}
+                  placeholder={t('languages:select_translations').toString()}
+                />
+              )}
             />
           </div>
           <div>

--- a/packages/web/src/features/languages/NewLanguageView.tsx
+++ b/packages/web/src/features/languages/NewLanguageView.tsx
@@ -60,14 +60,15 @@ export default function NewLanguageView() {
               {t('languages:code').toUpperCase()}
             </FormLabel>
             <TextInput
+              {...formContext.register('code', {
+                required: true,
+                validate: {
+                  valid: (code: string) => languageCodes.includes(code),
+                },
+              })}
               id="code"
-              name="code"
               className="w-full"
               autoComplete="off"
-              required
-              validate={{
-                valid: (code: string) => languageCodes.includes(code),
-              }}
               aria-describedby="code-error"
             />
             <InputError
@@ -84,11 +85,12 @@ export default function NewLanguageView() {
               {t('common:name').toUpperCase()}
             </FormLabel>
             <TextInput
+              {...formContext.register('name', {
+                required: true,
+              })}
               id="name"
-              name="name"
               className="w-full"
               autoComplete="off"
-              required
               aria-describedby="name-error"
             />
             <InputError

--- a/packages/web/src/features/users/AcceptInviteView.tsx
+++ b/packages/web/src/features/users/AcceptInviteView.tsx
@@ -6,7 +6,7 @@ import TextInput from '../../shared/components/form/TextInput';
 import View from '../../shared/components/View';
 import ViewTitle from '../../shared/components/ViewTitle';
 import apiClient from '../../shared/apiClient';
-import Form, { SubmitHandler } from '../../shared/components/form/Form';
+import Form from '../../shared/components/form/Form';
 import InputError from '../../shared/components/form/InputError';
 import Button from '../../shared/components/actions/Button';
 import SubmittingIndicator from '../../shared/components/form/SubmittingIndicator';
@@ -64,11 +64,7 @@ export default function AcceptInviteView() {
   const flash = useFlash();
 
   const formContext = useForm<FormData>();
-  const onSubmit: SubmitHandler<FormData> = async ({
-    firstName,
-    lastName,
-    password,
-  }) => {
+  async function onSubmit({ firstName, lastName, password }: FormData) {
     try {
       await apiClient.auth.acceptInvite({
         name: `${firstName} ${lastName}`,
@@ -84,7 +80,7 @@ export default function AcceptInviteView() {
     } catch (error) {
       flash.error(`${error}`);
     }
-  };
+  }
 
   return (
     <View fitToScreen className="flex justify-center items-start">

--- a/packages/web/src/features/users/AcceptInviteView.tsx
+++ b/packages/web/src/features/users/AcceptInviteView.tsx
@@ -108,11 +108,12 @@ export default function AcceptInviteView() {
                 {t('users:first_name').toUpperCase()}
               </FormLabel>
               <TextInput
+                {...formContext.register('firstName', {
+                  required: true,
+                })}
                 id="first-name"
-                name="firstName"
                 className="w-full"
                 autoComplete="given-name"
-                required
                 aria-describedby="first-name-error"
               />
               <InputError
@@ -126,11 +127,12 @@ export default function AcceptInviteView() {
                 {t('users:last_name').toUpperCase()}
               </FormLabel>
               <TextInput
+                {...formContext.register('lastName', {
+                  required: true,
+                })}
                 id="last-name"
-                name="lastName"
                 className="w-full"
                 autoComplete="family-name"
-                required
                 aria-describedby="last-name-error"
               />
               <InputError
@@ -145,13 +147,14 @@ export default function AcceptInviteView() {
               {t('users:password').toUpperCase()}
             </FormLabel>
             <TextInput
+              {...formContext.register('password', {
+                required: true,
+                minLength: 8,
+              })}
               type="password"
               id="password"
-              name="password"
               className="w-full"
               autoComplete="new-password"
-              required
-              minLength={8}
               aria-describedby="password-error"
             />
             <InputError
@@ -168,12 +171,17 @@ export default function AcceptInviteView() {
               {t('users:confirm_password').toUpperCase()}
             </FormLabel>
             <TextInput
+              {...formContext.register('confirmPassword', {
+                required: true,
+                validate: {
+                  confirms: (value: unknown) =>
+                    value === formContext.getValues().password,
+                },
+              })}
               type="password"
               id="confirm-password"
-              name="confirmPassword"
               className="w-full"
               autoComplete="new-password"
-              confirms="password"
               aria-describedby="confirm-password-error"
             />
             <InputError

--- a/packages/web/src/features/users/InviteUserView.tsx
+++ b/packages/web/src/features/users/InviteUserView.tsx
@@ -7,7 +7,7 @@ import TextInput from '../../shared/components/form/TextInput';
 import View from '../../shared/components/View';
 import ViewTitle from '../../shared/components/ViewTitle';
 import apiClient from '../../shared/apiClient';
-import Form, { SubmitHandler } from '../../shared/components/form/Form';
+import Form from '../../shared/components/form/Form';
 import InputError from '../../shared/components/form/InputError';
 import Button from '../../shared/components/actions/Button';
 import SubmittingIndicator from '../../shared/components/form/SubmittingIndicator';
@@ -22,12 +22,12 @@ export default function InviteUserView() {
   const flash = useFlash();
 
   const formContext = useForm<FormData>();
-  const onSubmit: SubmitHandler<FormData> = async ({ email }, { reset }) => {
+  async function onSubmit({ email }: FormData) {
     try {
       await apiClient.users.invite({ email });
 
       flash.success(t('users:user_invited'));
-      reset();
+      formContext.reset();
     } catch (error) {
       if (error instanceof ApiClientError && error.status === 409) {
         const alreadyExistsError = error.body.errors.find(
@@ -40,7 +40,7 @@ export default function InviteUserView() {
       }
       flash.error(`${error}`);
     }
-  };
+  }
 
   return (
     <View fitToScreen className="flex justify-center items-start">

--- a/packages/web/src/features/users/InviteUserView.tsx
+++ b/packages/web/src/features/users/InviteUserView.tsx
@@ -52,11 +52,12 @@ export default function InviteUserView() {
               {t('users:email').toUpperCase()}
             </FormLabel>
             <TextInput
+              {...formContext.register('email', {
+                required: true,
+              })}
               id="email"
-              name="email"
               className="w-full"
               autoComplete="off"
-              required
               aria-describedby="email-error"
             />
             <InputError

--- a/packages/web/src/features/users/LoginView.tsx
+++ b/packages/web/src/features/users/LoginView.tsx
@@ -6,7 +6,7 @@ import TextInput from '../../shared/components/form/TextInput';
 import View from '../../shared/components/View';
 import ViewTitle from '../../shared/components/ViewTitle';
 import apiClient from '../../shared/apiClient';
-import Form, { SubmitHandler } from '../../shared/components/form/Form';
+import Form from '../../shared/components/form/Form';
 import InputError from '../../shared/components/form/InputError';
 import Button from '../../shared/components/actions/Button';
 import SubmittingIndicator from '../../shared/components/form/SubmittingIndicator';
@@ -28,7 +28,7 @@ export default function InviteUserView() {
   const flash = useFlash();
 
   const formContext = useForm<FormData>();
-  const onSubmit: SubmitHandler<FormData> = async ({ email, password }) => {
+  async function onSubmit({ email, password }: FormData) {
     try {
       await apiClient.auth.login({ email, password });
       refreshAuth();
@@ -40,7 +40,7 @@ export default function InviteUserView() {
         flash.error(`${error}`);
       }
     }
-  };
+  }
 
   return (
     <View fitToScreen className="flex justify-center items-start">

--- a/packages/web/src/features/users/LoginView.tsx
+++ b/packages/web/src/features/users/LoginView.tsx
@@ -52,11 +52,12 @@ export default function InviteUserView() {
               {t('users:email').toUpperCase()}
             </FormLabel>
             <TextInput
+              {...formContext.register('email', {
+                required: true,
+              })}
               id="email"
-              name="email"
               className="w-full"
               autoComplete="username"
-              required
               aria-describedby="email-error"
             />
             <InputError
@@ -72,12 +73,13 @@ export default function InviteUserView() {
               {t('users:password').toUpperCase()}
             </FormLabel>
             <TextInput
+              {...formContext.register('password', {
+                required: true,
+              })}
               id="password"
               type="password"
-              name="password"
               className="w-full"
               autoComplete="current-password"
-              required
               aria-describedby="password-error"
             />
             <InputError

--- a/packages/web/src/features/users/UpdateProfileView.tsx
+++ b/packages/web/src/features/users/UpdateProfileView.tsx
@@ -1,12 +1,12 @@
 import { useTranslation } from 'react-i18next';
-import { useForm } from 'react-hook-form';
+import { useForm, SubmitHandler } from 'react-hook-form';
 import Card from '../../shared/components/Card';
 import FormLabel from '../../shared/components/form/FormLabel';
 import TextInput from '../../shared/components/form/TextInput';
 import View from '../../shared/components/View';
 import ViewTitle from '../../shared/components/ViewTitle';
 import apiClient from '../../shared/apiClient';
-import Form, { SubmitHandler } from '../../shared/components/form/Form';
+import Form from '../../shared/components/form/Form';
 import InputError from '../../shared/components/form/InputError';
 import Button from '../../shared/components/actions/Button';
 import SubmittingIndicator from '../../shared/components/form/SubmittingIndicator';
@@ -35,11 +35,7 @@ export default function UpdateProfileView() {
     }
   }, [setValue, user]);
 
-  const onSubmit: SubmitHandler<FormData> = async ({
-    email,
-    name,
-    password,
-  }) => {
+  async function onSubmit({ email, name, password }: FormData) {
     try {
       if (user) {
         await apiClient.users.update({
@@ -59,7 +55,7 @@ export default function UpdateProfileView() {
     } catch (error) {
       flash.error(`${error}`);
     }
-  };
+  }
 
   if (!user) return null;
 

--- a/packages/web/src/features/users/UpdateProfileView.tsx
+++ b/packages/web/src/features/users/UpdateProfileView.tsx
@@ -73,12 +73,13 @@ export default function UpdateProfileView() {
               {t('users:email').toUpperCase()}
             </FormLabel>
             <TextInput
+              {...formContext.register('email', {
+                required: true,
+              })}
               id="email"
-              name="email"
               type="email"
               className="w-full"
               autoComplete="email"
-              required
               aria-describedby="email-error"
             />
             <InputError
@@ -92,11 +93,12 @@ export default function UpdateProfileView() {
               {t('common:name').toUpperCase()}
             </FormLabel>
             <TextInput
+              {...formContext.register('name', {
+                required: true,
+              })}
               id="name"
-              name="name"
               className="w-full"
               autoComplete="name"
-              required
               aria-describedby="name-error"
             />
             <InputError
@@ -110,12 +112,13 @@ export default function UpdateProfileView() {
               {t('users:password').toUpperCase()}
             </FormLabel>
             <TextInput
+              {...formContext.register('password', {
+                minLength: 8,
+              })}
               type="password"
               id="password"
-              name="password"
               className="w-full"
               autoComplete="new-password"
-              minLength={8}
               aria-describedby="password-error"
             />
             <InputError
@@ -132,12 +135,16 @@ export default function UpdateProfileView() {
               {t('users:confirm_password').toUpperCase()}
             </FormLabel>
             <TextInput
+              {...formContext.register('confirmPassword', {
+                validate: {
+                  confirms: (value: unknown) =>
+                    value === formContext.getValues().password,
+                },
+              })}
               type="password"
               id="confirm-password"
-              name="confirmPassword"
               className="w-full"
               autoComplete="new-password"
-              confirms="password"
               aria-describedby="confirm-password-error"
             />
             <InputError

--- a/packages/web/src/features/users/UsersView.tsx
+++ b/packages/web/src/features/users/UsersView.tsx
@@ -111,7 +111,6 @@ export default function UsersView() {
                   <ComboboxInput
                     className="w-42"
                     autoComplete="off"
-                    name="userRole"
                     value={user.systemRoles?.[0] ?? ''}
                     aria-label={t('users:role') ?? ''}
                     onChange={(role) =>

--- a/packages/web/src/shared/components/ConfirmationDialog.tsx
+++ b/packages/web/src/shared/components/ConfirmationDialog.tsx
@@ -102,11 +102,11 @@ const ConfirmationDialog = forwardRef<
                 </p>
                 <Form context={formContext} onSubmit={() => handleResult(true)}>
                   <TextInput
+                    {...formContext.register('confirm', { required: true })}
                     id="confirm"
                     name="confirm"
                     className="w-full"
                     autoComplete="off"
-                    required
                     onChange={(event) =>
                       setEnableConfirmationButton(
                         event.target.value === confirmationValue

--- a/packages/web/src/shared/components/form/ButtonSelectorInput.tsx
+++ b/packages/web/src/shared/components/form/ButtonSelectorInput.tsx
@@ -33,11 +33,7 @@ export function ButtonSelectorInput({
   ...props
 }: ButtonSelectorInputProps) {
   const formContext = useFormContext();
-  const hasErrors = !!(
-    formContext &&
-    name &&
-    formContext.getFieldState(name).error
-  );
+  const hasErrors = !!(name && formContext?.getFieldState(name).error);
 
   return (
     <ButtonSelectorContext.Provider

--- a/packages/web/src/shared/components/form/ButtonSelectorInput.tsx
+++ b/packages/web/src/shared/components/form/ButtonSelectorInput.tsx
@@ -3,8 +3,10 @@ import { useFormContext } from 'react-hook-form';
 
 interface ButtonSelectorContextValue {
   name: string;
+  value?: string;
+  onChange?(value: string): void;
   defaultValue?: string;
-  required?: boolean;
+  hasErrors: boolean;
 }
 
 const ButtonSelectorContext = createContext<ButtonSelectorContextValue | null>(
@@ -12,24 +14,35 @@ const ButtonSelectorContext = createContext<ButtonSelectorContextValue | null>(
 );
 
 export interface ButtonSelectorInputProps
-  extends Omit<ComponentProps<'fieldset'>, 'defaultValue'> {
+  extends Omit<
+    ComponentProps<'fieldset'>,
+    'defaultValue' | 'value' | 'onChange'
+  > {
   name: string;
+  value?: string;
+  onChange?(value: string): void;
   defaultValue?: string;
-  required?: boolean;
 }
 
 export function ButtonSelectorInput({
+  value,
+  onChange,
   children,
   name,
   defaultValue,
-  required,
   ...props
 }: ButtonSelectorInputProps) {
   const formContext = useFormContext();
-  const hasErrors = !!formContext?.formState.errors[name];
+  const hasErrors = !!(
+    formContext &&
+    name &&
+    formContext.getFieldState(name).error
+  );
 
   return (
-    <ButtonSelectorContext.Provider value={{ name, defaultValue, required }}>
+    <ButtonSelectorContext.Provider
+      value={{ name, defaultValue, hasErrors, value, onChange }}
+    >
       <fieldset
         className={`
           inline-block rounded
@@ -61,12 +74,6 @@ export function ButtonSelectorOption({
   if (!selectorContext)
     throw new Error('ButtonSelectorOption must be within a ButtonSelector');
 
-  const formContext = useFormContext();
-  const hasErrors = !!formContext?.formState.errors[selectorContext.name];
-  const registerProps = formContext?.register(selectorContext.name, {
-    required: selectorContext.required,
-  });
-
   return (
     <label
       className={`
@@ -75,16 +82,27 @@ export function ButtonSelectorOption({
         rtl:last:rounded-l rtl:last:border-l rtl:first:rounded-r
         [&:has(:checked)]:bg-slate-900 [&:has(:checked)]:text-white
         shadow-inner [&:has(:checked)]:shadow-none
-        ${hasErrors ? 'border-red-700 shadow-red-100' : 'border-slate-400'}
+        ${
+          selectorContext.hasErrors
+            ? 'border-red-700 shadow-red-100'
+            : 'border-slate-400'
+        }
       `}
     >
       <input
-        {...registerProps}
         className="absolute opacity-0"
         type="radio"
         name={selectorContext.name}
-        defaultChecked={selectorContext.defaultValue === value}
         value={value}
+        checked={
+          selectorContext.value ? selectorContext.value === value : undefined
+        }
+        defaultChecked={
+          selectorContext.defaultValue
+            ? selectorContext.defaultValue === value
+            : undefined
+        }
+        onChange={(e) => selectorContext.onChange?.(e.target.value)}
       />
       {children}
     </label>

--- a/packages/web/src/shared/components/form/ComboboxInput.tsx
+++ b/packages/web/src/shared/components/form/ComboboxInput.tsx
@@ -6,11 +6,10 @@ import {
   useEffect,
   useState,
 } from 'react';
-import { Controller, useFormContext } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Icon } from '../Icon';
 
-const CREATE_TAG = '_create';
 const MAX_ITEMS = 1000;
 
 export interface ComboboxItem {
@@ -18,85 +17,25 @@ export interface ComboboxItem {
   value: string;
 }
 
-export type ComboboxInputProps = BaseComboboxInputProps & {
-  required?: boolean;
-  isolate?: boolean;
-};
-
-export default function ComboboxInput(props: ComboboxInputProps) {
-  const context = useFormContext();
-
-  if (context && !props.isolate) {
-    return (
-      <Controller
-        control={context.control}
-        name={props.name}
-        defaultValue={props.defaultValue}
-        rules={{ required: props.required }}
-        render={({ field, fieldState }) => (
-          <BaseComboboxInput
-            {...field}
-            items={props.items}
-            hasErrors={!!fieldState.error}
-          />
-        )}
-      />
-    );
-  } else {
-    const {
-      className,
-      name,
-      items,
-      value,
-      defaultValue,
-      hasErrors,
-      up,
-      onBlur,
-      onChange,
-      onCreate,
-      onKeyDown,
-    } = props;
-    return (
-      <BaseComboboxInput
-        className={className}
-        name={name}
-        items={items}
-        value={value}
-        defaultValue={defaultValue}
-        hasErrors={hasErrors}
-        up={up}
-        onBlur={onBlur}
-        onChange={onChange}
-        onCreate={onCreate}
-        onKeyDown={onKeyDown}
-      />
-    );
-  }
-}
-
 interface BaseComboboxInputProps
   extends Omit<ComponentProps<'input'>, 'value' | 'onChange' | 'ref'> {
   className?: string;
-  name: string;
+  name?: string;
   items: ComboboxItem[];
   value?: string;
   defaultValue?: string;
-  hasErrors?: boolean;
   up?: boolean;
   onBlur?(): void;
   onChange?(value: string): void;
-  onCreate?(text?: string): void;
   onKeyDown?: KeyboardEventHandler<HTMLInputElement>;
 }
 
-const BaseComboboxInput = forwardRef<HTMLInputElement, BaseComboboxInputProps>(
+const ComboboxInput = forwardRef<HTMLInputElement, BaseComboboxInputProps>(
   (
     {
       className = '',
-      hasErrors,
       value = '',
       onChange,
-      onCreate,
       onBlur,
       items,
       name,
@@ -111,6 +50,13 @@ const BaseComboboxInput = forwardRef<HTMLInputElement, BaseComboboxInputProps>(
     const [normalizedInputValue, setNormalizedInputValue] = useState('');
     const [filteredItems, setFilteredItems] = useState<ComboboxItem[]>(items);
 
+    const formContext = useFormContext();
+    const hasErrors = !!(
+      formContext &&
+      name &&
+      formContext.getFieldState(name).error
+    );
+
     // If none of the items matches the input value exactly,
     // then we want to give the option of creating a new item.
     useEffect(() => {
@@ -120,31 +66,11 @@ const BaseComboboxInput = forwardRef<HTMLInputElement, BaseComboboxInputProps>(
             ignoreDiacritics(normalizedInputValue.toLowerCase())
           )
         );
-        const noExactMatch = filteredItems.every(
-          (item) => item.label.normalize('NFD') !== normalizedInputValue
-        );
-        if (noExactMatch && !!onCreate) {
-          setFilteredItems([
-            { value: CREATE_TAG, label: normalizedInputValue },
-            ...filteredItems,
-          ]);
-        } else {
-          setFilteredItems(filteredItems);
-        }
+        setFilteredItems(filteredItems);
       } else {
         setFilteredItems(items);
       }
-    }, [items, normalizedInputValue, onCreate]);
-
-    function onComboboxChange(newValue: string) {
-      if (newValue === CREATE_TAG) {
-        onCreate?.(normalizedInputValue);
-      } else {
-        if (newValue !== value) {
-          onChange?.(newValue);
-        }
-      }
-    }
+    }, [items, normalizedInputValue]);
 
     return (
       <div
@@ -154,7 +80,7 @@ const BaseComboboxInput = forwardRef<HTMLInputElement, BaseComboboxInputProps>(
       >
         <Combobox
           value={value}
-          onChange={onComboboxChange}
+          onChange={onChange}
           name={name}
           disabled={disabled}
         >
@@ -204,14 +130,7 @@ const BaseComboboxInput = forwardRef<HTMLInputElement, BaseComboboxInputProps>(
                   key={item.value}
                   value={item.value}
                 >
-                  {item.value === CREATE_TAG ? (
-                    <>
-                      <Icon icon="add" /> "
-                      <span className="italic">{item.label}</span>"
-                    </>
-                  ) : (
-                    item.label
-                  )}
+                  {item.label}
                 </Combobox.Option>
               ))
             )}
@@ -221,6 +140,8 @@ const BaseComboboxInput = forwardRef<HTMLInputElement, BaseComboboxInputProps>(
     );
   }
 );
+
+export default ComboboxInput;
 
 /**
  * Return a version of the word where all diacritics have been removed.

--- a/packages/web/src/shared/components/form/ComboboxInput.tsx
+++ b/packages/web/src/shared/components/form/ComboboxInput.tsx
@@ -51,11 +51,7 @@ const ComboboxInput = forwardRef<HTMLInputElement, BaseComboboxInputProps>(
     const [filteredItems, setFilteredItems] = useState<ComboboxItem[]>(items);
 
     const formContext = useFormContext();
-    const hasErrors = !!(
-      formContext &&
-      name &&
-      formContext.getFieldState(name).error
-    );
+    const hasErrors = !!(name && formContext?.getFieldState(name).error);
 
     // If none of the items matches the input value exactly,
     // then we want to give the option of creating a new item.

--- a/packages/web/src/shared/components/form/Form.tsx
+++ b/packages/web/src/shared/components/form/Form.tsx
@@ -1,9 +1,11 @@
 import { ComponentProps } from 'react';
-import { FormProvider, FieldValues, UseFormReturn } from 'react-hook-form';
+import {
+  FormProvider,
+  FieldValues,
+  UseFormReturn,
+  SubmitHandler,
+} from 'react-hook-form';
 
-export interface SubmitHandler<Data> {
-  (data: Data, options: { reset(): void }): Promise<void> | void;
-}
 export interface FormProps<Data extends FieldValues>
   extends Omit<ComponentProps<'form'>, 'onSubmit'> {
   context: UseFormReturn<Data>;
@@ -24,7 +26,7 @@ export default function Form<Data extends FieldValues>({
       onSubmit={(e) => {
         if (!formState.isSubmitting) {
           handleSubmit(async (data) => {
-            await onSubmit(data, { reset: context.reset });
+            await onSubmit(data);
           })(e);
         } else {
           e.preventDefault();

--- a/packages/web/src/shared/components/form/MultiselectInput.tsx
+++ b/packages/web/src/shared/components/form/MultiselectInput.tsx
@@ -1,58 +1,23 @@
 import { forwardRef } from 'react';
 import { Combobox } from '@headlessui/react';
-import { Controller, useFormContext } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 import { Icon } from '../Icon';
 
-export type MultiselectInputProps = BaseMultiselectInputProps & {
-  required?: boolean;
-  isolate?: boolean;
-};
-
-export default function MultiselectInput(props: MultiselectInputProps) {
-  const context = useFormContext();
-
-  if (context && !props.isolate) {
-    return (
-      <Controller
-        control={context.control}
-        name={props.name}
-        defaultValue={props.defaultValue}
-        rules={{ required: props.required }}
-        render={({ field, fieldState }) => (
-          <BaseMultiselectInput
-            {...field}
-            items={props.items}
-            hasErrors={!!fieldState.error}
-            placeholder={props.placeholder}
-          />
-        )}
-      />
-    );
-  } else {
-    return <BaseMultiselectInput {...props} />;
-  }
-}
-
-interface BaseMultiselectInputProps {
+export interface MultiselectInputProps {
   className?: string;
   name: string;
   items: { label: string; value: string }[];
   value?: string[];
   defaultValue?: string[];
-  hasErrors?: boolean;
   placeholder?: string;
   onChange?(value: string[]): void;
   onBlur?(): void;
 }
 
-const BaseMultiselectInput = forwardRef<
-  HTMLInputElement,
-  BaseMultiselectInputProps
->(
+const MultiselectInput = forwardRef<HTMLInputElement, MultiselectInputProps>(
   (
     {
       className = '',
-      hasErrors,
       value,
       onChange,
       onBlur,
@@ -63,6 +28,13 @@ const BaseMultiselectInput = forwardRef<
     },
     ref
   ) => {
+    const formContext = useFormContext();
+    const hasErrors = !!(
+      formContext &&
+      name &&
+      formContext.getFieldState(name).error
+    );
+
     return (
       <div className={`${className} group/multiselect relative`}>
         <Combobox
@@ -122,3 +94,5 @@ const BaseMultiselectInput = forwardRef<
     );
   }
 );
+
+export default MultiselectInput;

--- a/packages/web/src/shared/components/form/MultiselectInput.tsx
+++ b/packages/web/src/shared/components/form/MultiselectInput.tsx
@@ -29,11 +29,7 @@ const MultiselectInput = forwardRef<HTMLInputElement, MultiselectInputProps>(
     ref
   ) => {
     const formContext = useFormContext();
-    const hasErrors = !!(
-      formContext &&
-      name &&
-      formContext.getFieldState(name).error
-    );
+    const hasErrors = !!(name && formContext?.getFieldState(name).error);
 
     return (
       <div className={`${className} group/multiselect relative`}>

--- a/packages/web/src/shared/components/form/SortableMultiselectInput.tsx
+++ b/packages/web/src/shared/components/form/SortableMultiselectInput.tsx
@@ -144,7 +144,6 @@ const BaseSortableMultiselectInput = forwardRef<
           items={availableNewItems}
           disabled={availableNewItems.length === 0}
           autoComplete="off"
-          isolate
         />
         <Button onClick={addItem} onBlur={onBlur}>
           <Icon icon="add" />

--- a/packages/web/src/shared/components/form/SortableMultiselectInput.tsx
+++ b/packages/web/src/shared/components/form/SortableMultiselectInput.tsx
@@ -1,50 +1,13 @@
 import { forwardRef, useState } from 'react';
-import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Icon } from '../Icon';
 import Button from '../actions/Button';
 import ComboboxInput from './ComboboxInput';
-
-export type SortableMultiselectInputProps =
-  BaseSortableMultiselectInputProps & {
-    required?: boolean;
-    isolate?: boolean;
-  };
-
-export default function SortableMultiselectInput(
-  props: SortableMultiselectInputProps
-) {
-  const context = useFormContext();
-
-  if (context && !props.isolate) {
-    return (
-      <Controller
-        control={context.control}
-        name={props.name}
-        defaultValue={props.defaultValue}
-        rules={{ required: props.required }}
-        render={({ field, fieldState }) => (
-          <BaseSortableMultiselectInput
-            {...field}
-            items={props.items}
-            hasErrors={!!fieldState.error}
-            placeholder={props.placeholder}
-          />
-        )}
-      />
-    );
-  } else {
-    return <BaseSortableMultiselectInput {...props} />;
-  }
-}
-
-interface BaseSortableMultiselectInputProps {
+interface SortableMultiselectInputProps {
   className?: string;
   name: string;
   items: ItemType[];
   value?: string[];
-  defaultValue?: string[];
-  hasErrors?: boolean;
   placeholder?: string;
   onChange?(value: string[]): void;
   onBlur?(): void;
@@ -52,9 +15,9 @@ interface BaseSortableMultiselectInputProps {
 
 type ItemType = { label: string; value: string };
 
-const BaseSortableMultiselectInput = forwardRef<
+const SortableMultiselectInput = forwardRef<
   HTMLInputElement,
-  BaseSortableMultiselectInputProps
+  SortableMultiselectInputProps
 >(({ className = '', value, onChange, onBlur, items }, ref) => {
   const selected: string[] = value ?? [];
   const { t } = useTranslation(['common']);
@@ -153,3 +116,5 @@ const BaseSortableMultiselectInput = forwardRef<
     </div>
   );
 });
+
+export default SortableMultiselectInput;

--- a/packages/web/src/shared/components/form/TextInput.tsx
+++ b/packages/web/src/shared/components/form/TextInput.tsx
@@ -6,7 +6,7 @@ export type TextInputProps = ComponentProps<'input'>;
 const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
   ({ className = '', ...props }, ref) => {
     const context = useFormContext();
-    const hasErrors = props.name && !!context?.formState.errors[props.name];
+    const hasErrors = !!(props.name && context?.formState.errors[props.name]);
 
     return (
       <input

--- a/packages/web/src/shared/components/form/TextInput.tsx
+++ b/packages/web/src/shared/components/form/TextInput.tsx
@@ -1,38 +1,16 @@
 import { ComponentProps, forwardRef } from 'react';
-import { Validate, useFormContext } from 'react-hook-form';
-import useMergedRef from '../../hooks/mergeRefs';
+import { useFormContext } from 'react-hook-form';
 
-export interface TextInputProps extends Omit<ComponentProps<'input'>, 'name'> {
-  name: string;
-  confirms?: string;
-  validate?: Record<string, Validate<any, any>>;
-}
+export type TextInputProps = ComponentProps<'input'>;
 
 const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
-  (
-    { className = '', required, minLength, confirms, validate, ...props },
-    ref
-  ) => {
+  ({ className = '', ...props }, ref) => {
     const context = useFormContext();
-    const hasErrors = !!context?.formState.errors[props.name];
-    validate ??= {};
-    if (confirms) {
-      validate.confirms = (value: unknown) =>
-        value === context.getValues()[confirms];
-    }
-    const registerProps = context?.register(props.name, {
-      required,
-      minLength: minLength,
-      ...(confirms && {
-        deps: confirms,
-      }),
-      validate,
-      onChange: props.onChange,
-      onBlur: props.onBlur,
-    });
+    const hasErrors = props.name && !!context?.formState.errors[props.name];
 
     return (
       <input
+        ref={ref}
         className={`
           border rounded shadow-inner py-2 px-3 h-10
           focus:outline focus:outline-2
@@ -44,8 +22,6 @@ const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
           ${className}
         `}
         {...props}
-        {...registerProps}
-        ref={useMergedRef(ref, registerProps?.ref)}
       />
     );
   }


### PR DESCRIPTION
<!--
  Thank you for your PR! Please follow this template to help us review your PR quickly.
-->

## What has changed

The goal here is to simplify the abstractions we are using for building forms. Here is what that entails:
* Remove the implicit dependency of form inputs on the FormContext - this allows components to be composed together into a more complex form input that itself is connected to the FormContext by a Controller, and for components to be used outside of a form
* Use Controller for complex uncontrolled inputs - I was trying to hide this inside the input components but it makes things harder to debug. Instead we should just get comfortable without how react-hook-form is designed to be used.
* Use the form context as the source of truth when form state needs to be rendered - Inside a form we don't need to use onChange and useState to keep track of data that we want to render in the template. Instead we can use formContext.watch to get the reactive state

<!--
  Please name your PR following conventional commits.
  https://www.conventionalcommits.org/en/v1.0.0/
  The main ones to use are `feat`, `fix`, `chore`, `build`, `refactor`, and `docs`.

  If your PR is not connected to an issue, please describe the reason for your
  changes. Please also describe what you have changed. For more complex changes, include a self review that goes into more detail. Please also call attention to breaking changes, particularly in the shape of API routes.
-->

## Connected Issues

closes #318 

<!--
  If this PR resolves an issue, please add `closes #issue-no` below to connect the issue to the PR.
-->

## QA Steps

Click on a few forms to ensure they still work as expected.

<!-- Please describe how to test what you've changed. -->

## Post-Deployment

<!--
  Please describe any tasks that must be executed after this change is deployed.
-->

- [x] Nothing required
