### PR TITLE
build: cachebust landing page assets when contents change

### DIFF
--- a/packages/landing/cachebust
+++ b/packages/landing/cachebust
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+SHA_BIN="sha256sum"
+
+if [ $(uname) = "Darwin" ]; then
+  SHA_BIN="shasum"
+fi
+
+root="../../dist/packages/landing"
+filename="$1"
+
+hash=$("$SHA_BIN" "$root/$filename" | awk '{print $1}')
+hashed_filename="${filename%.*}.${hash:0:12}.${filename##*.}"
+
+files="../../dist/packages/landing/index.html"
+
+mv "$root/$filename" "$root/$hashed_filename"
+for file in $files; do
+  sed -i.bak "s/${filename//\//\\/}/${hashed_filename//\//\\/}/g" "$file"
+  rm "$file.bak"
+done

--- a/packages/landing/project.json
+++ b/packages/landing/project.json
@@ -15,7 +15,10 @@
           "mkdir -p ../../dist/packages/landing/assets",
           "npx tailwindcss -i tailwind.css -o ../../dist/packages/landing/styles.css",
           "cp assets/* ../../dist/packages/landing/assets/",
-          "cp index.html ../../dist/packages/landing/"
+          "cp index.html ../../dist/packages/landing/",
+          "./cachebust styles.css",
+          "./cachebust assets/hero.png",
+          "./cachebust assets/logo.png"
         ],
         "parallel": false
       }


### PR DESCRIPTION
<!--
  Thank you for your PR! Please follow this template to help us review your PR quickly.
-->

## What has changed

After copying files to dist folder, renames file with hash based on file contents and then updates assets urls in the index.html. This ensures the hash only changes when the file has actually changed. Pretty crude, but gets the job done.

This probably won't work on windows because it requires the sha256sum or shasum binary. I'm ok with that because this only needs to run on CI, not locally. We don't need file hashes in our dev environments.

<!--
  Please name your PR following conventional commits.
  https://www.conventionalcommits.org/en/v1.0.0/
  The main ones to use are `feat`, `fix`, `chore`, `build`, `refactor`, and `docs`.

  If your PR is not connected to an issue, please describe the reason for your
  changes. Please also describe what you have changed. For more complex changes, include a self review that goes into more detail. Please also call attention to breaking changes, particularly in the shape of API routes.
-->

## Connected Issues

closes #364 

<!--
  If this PR resolves an issue, please add `closes #issue-no` below to connect the issue to the PR.
-->
