### PR TITLE
refactor: migrate db schema to track phrases

### DIFF
--- a/packages/api/pages/api/languages/[code]/words/[wordId]/footnote.ts
+++ b/packages/api/pages/api/languages/[code]/words/[wordId]/footnote.ts
@@ -28,25 +28,43 @@ export default createRoute<{ code: string; wordId: string }>()
         throw Error('No session user.');
       }
 
-      const fields = {
-        timestamp: new Date(),
-        authorId: req.session.user.id,
-        content: req.body.note,
-      };
-      await client.footnote.upsert({
-        where: {
-          wordId_languageId: {
-            wordId: req.query.wordId,
-            languageId: language.id,
-          },
-        },
-        update: fields,
-        create: {
-          ...fields,
-          wordId: req.query.wordId,
-          languageId: language.id,
-        },
-      });
+      const timestamp = new Date();
+      await client.$executeRaw`
+        WITH phrase AS (
+          SELECT "phraseId", "wordId" FROM "PhraseWord"
+          JOIN "Phrase" ON "Phrase".id = "PhraseWord"."phraseId"
+          WHERE "PhraseWord"."wordId" = ${req.query.wordId}
+            AND "Phrase"."languageId" = ${language.id}::uuid
+        ),
+        new_phrase AS (
+          INSERT INTO "Phrase" ("languageId")
+          SELECT ${language.id}::uuid
+          WHERE NOT EXISTS (SELECT * FROM phrase)
+          RETURNING "id"
+        ),
+        new_phrase_word AS (
+          INSERT INTO "PhraseWord" ("phraseId", "wordId")
+          SELECT new_phrase.id, ${req.query.wordId}
+          FROM new_phrase
+          RETURNING "phraseId", "wordId"
+        ),
+        upsert_phrase AS (
+          (SELECT * FROM phrase) UNION (SELECT * FROM new_phrase_word)
+        )
+        INSERT INTO "Footnote" ("wordId", "languageId", "phraseId", "content", "authorId", "timestamp")
+        SELECT
+          ${req.query.wordId},
+          ${language.id}::uuid,
+          upsert_phrase."phraseId",
+          ${req.body.note},
+          ${req.session.user.id}::uuid,
+          ${timestamp}
+        FROM upsert_phrase
+        ON CONFLICT ("phraseId") DO UPDATE SET
+          "content" = ${req.body.note},
+          "authorId" = ${req.session.user.id}::uuid,
+          "timestamp" = ${timestamp}
+      `;
 
       res.ok();
     },

--- a/packages/db/src/migrations/20240330220118_add_phrases/migration.sql
+++ b/packages/db/src/migrations/20240330220118_add_phrases/migration.sql
@@ -1,0 +1,64 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[phraseId]` on the table `Footnote` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[phraseId]` on the table `Gloss` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[phraseId]` on the table `TranslatorNote` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "Footnote" ADD COLUMN     "phraseId" INTEGER;
+
+-- AlterTable
+ALTER TABLE "Gloss" ADD COLUMN     "phraseId" INTEGER;
+
+-- AlterTable
+ALTER TABLE "TranslatorNote" ADD COLUMN     "phraseId" INTEGER;
+
+-- CreateTable
+CREATE TABLE "Phrase" (
+    "id" SERIAL NOT NULL,
+    "languageId" UUID NOT NULL,
+
+    CONSTRAINT "Phrase_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PhraseWord" (
+    "phraseId" INTEGER NOT NULL,
+    "wordId" TEXT NOT NULL,
+
+    CONSTRAINT "PhraseWord_pkey" PRIMARY KEY ("phraseId","wordId")
+);
+-- DropForeignKey
+ALTER TABLE "PhraseWord" DROP CONSTRAINT "PhraseWord_phraseId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "PhraseWord" ADD CONSTRAINT "PhraseWord_phraseId_fkey" FOREIGN KEY ("phraseId") REFERENCES "Phrase"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Footnote_phraseId_key" ON "Footnote"("phraseId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Gloss_phraseId_key" ON "Gloss"("phraseId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TranslatorNote_phraseId_key" ON "TranslatorNote"("phraseId");
+
+-- AddForeignKey
+ALTER TABLE "Phrase" ADD CONSTRAINT "Phrase_languageId_fkey" FOREIGN KEY ("languageId") REFERENCES "Language"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PhraseWord" ADD CONSTRAINT "PhraseWord_phraseId_fkey" FOREIGN KEY ("phraseId") REFERENCES "Phrase"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PhraseWord" ADD CONSTRAINT "PhraseWord_wordId_fkey" FOREIGN KEY ("wordId") REFERENCES "Word"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Gloss" ADD CONSTRAINT "Gloss_phraseId_fkey" FOREIGN KEY ("phraseId") REFERENCES "Phrase"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TranslatorNote" ADD CONSTRAINT "TranslatorNote_phraseId_fkey" FOREIGN KEY ("phraseId") REFERENCES "Phrase"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Footnote" ADD CONSTRAINT "Footnote_phraseId_fkey" FOREIGN KEY ("phraseId") REFERENCES "Phrase"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/src/migrations/20240330220118_add_phrases/migration.sql
+++ b/packages/db/src/migrations/20240330220118_add_phrases/migration.sql
@@ -30,11 +30,6 @@ CREATE TABLE "PhraseWord" (
 
     CONSTRAINT "PhraseWord_pkey" PRIMARY KEY ("phraseId","wordId")
 );
--- DropForeignKey
-ALTER TABLE "PhraseWord" DROP CONSTRAINT "PhraseWord_phraseId_fkey";
-
--- AddForeignKey
-ALTER TABLE "PhraseWord" ADD CONSTRAINT "PhraseWord_phraseId_fkey" FOREIGN KEY ("phraseId") REFERENCES "Phrase"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- CreateIndex
 CREATE UNIQUE INDEX "Footnote_phraseId_key" ON "Footnote"("phraseId");

--- a/packages/db/src/schema.prisma
+++ b/packages/db/src/schema.prisma
@@ -310,7 +310,7 @@ model PhraseWord {
   phrase   Phrase @relation(fields: [phraseId], references: [id], onDelete: Cascade)
   /// The ID of the phrase the word is in.
   phraseId Int
-  /// The word being connecte to a phrase.
+  /// The word being connected to a phrase.
   word     Word   @relation(fields: [wordId], references: [id])
   /// The ID of the word being connecte to a phrase.
   wordId   String

--- a/packages/db/src/schema.prisma
+++ b/packages/db/src/schema.prisma
@@ -177,6 +177,8 @@ model Word {
   translatorNotes TranslatorNote[]
   // The list of footnotes in different languages for this word.
   footnotes       Footnote[]
+  /// The list of phrases this word is connected to in different languages.
+  phrases         PhraseWord[]
 
   @@index([formId])
 }
@@ -240,6 +242,8 @@ model Language {
   roles               LanguageMemberRole[]
   /// The pending import job if any.
   importJob           LanguageImportJob?
+  /// The phrases in this language.
+  phrases             Phrase[]
 }
 
 /// Keeps track of a language import job.
@@ -282,6 +286,38 @@ model LanguageMemberRole {
   @@id([languageId, userId, role])
 }
 
+// A phrase connects one or more words into a single unit for a single language.
+model Phrase {
+  id         Int      @id @default(autoincrement())
+  /// The language the phrase belongs to.
+  language   Language @relation(fields: [languageId], references: [id])
+  /// The ID of the language the phrase belongs to.
+  languageId String   @db.Uuid
+
+  /// The list of words in the phrase.
+  words          PhraseWord[]
+  /// The gloss for the phrase
+  gloss          Gloss?
+  /// The translator note for the phrase.
+  translatorNote TranslatorNote?
+  /// The footnote for the phrase.
+  footnote       Footnote?
+}
+
+// Connects one or more words to a phrase in a language.
+model PhraseWord {
+  /// The phrase the word is in.
+  phrase   Phrase @relation(fields: [phraseId], references: [id], onDelete: Cascade)
+  /// The ID of the phrase the word is in.
+  phraseId Int
+  /// The word being connecte to a phrase.
+  word     Word   @relation(fields: [wordId], references: [id])
+  /// The ID of the word being connecte to a phrase.
+  wordId   String
+
+  @@id([phraseId, wordId])
+}
+
 enum GlossState {
   APPROVED
   UNAPPROVED
@@ -301,6 +337,10 @@ model Gloss {
   gloss      String?
   /// The approval state of the gloss.
   state      GlossState @default(UNAPPROVED)
+  /// The phrase the gloss applies to.
+  phrase     Phrase?    @relation(fields: [phraseId], references: [id])
+  /// The ID of phrase the gloss applies to.
+  phraseId   Int?       @unique
 
   @@id([wordId, languageId])
 }
@@ -391,6 +431,10 @@ model TranslatorNote {
   timestamp  DateTime
   /// The content of the note.
   content    String
+  /// The phrase the note applies to.
+  phrase     Phrase?  @relation(fields: [phraseId], references: [id])
+  /// The ID of phrase the note applies to.
+  phraseId   Int?     @unique
 
   @@id([wordId, languageId])
 }
@@ -413,6 +457,10 @@ model Footnote {
   timestamp  DateTime
   /// The content of the note.
   content    String
+  /// The phrase the note applies to.
+  phrase     Phrase?  @relation(fields: [phraseId], references: [id])
+  /// The ID of phrase the note applies to.
+  phraseId   Int?     @unique
 
   @@id([wordId, languageId])
 }

--- a/packages/db/src/sql/migrate-language-phrases.sql
+++ b/packages/db/src/sql/migrate-language-phrases.sql
@@ -1,0 +1,51 @@
+DO
+$$
+DECLARE
+	lang_id UUID = '018bba5e-1a95-fd70-37e1-fc2289701fff'::uuid;
+BEGIN
+	WITH word AS (
+		SELECT DISTINCT ON("wordId") *, ROW_NUMBER() OVER () AS r FROM (
+			SELECT "wordId" FROM "Gloss"
+			WHERE "phraseId" IS NULL
+				AND "languageId" = lang_id
+			UNION
+			SELECT "wordId" FROM "TranslatorNote"
+			WHERE "phraseId" IS NULL
+				AND "languageId" = lang_id
+			UNION
+			SELECT "wordId" FROM "Footnote"
+			WHERE "phraseId" IS NULL
+				AND "languageId" = lang_id
+		) AS combined
+	),
+	phrase AS (
+		INSERT INTO "Phrase" ("languageId")
+		SELECT '018bba5e-1a95-fd70-37e1-fc2289701fff'::uuid FROM word
+		RETURNING "id", "languageId"
+	),
+	phrase_word AS (
+		INSERT INTO "PhraseWord" ("phraseId", "wordId")
+		SELECT phrase.id, word."wordId" FROM word
+		JOIN (SELECT *, ROW_NUMBER() OVER () AS r FROM phrase) AS phrase
+			ON phrase.r = word.r
+		RETURNING "phraseId", "wordId"
+	),
+	gloss_update AS (
+		UPDATE "Gloss"
+		SET "phraseId" = phrase_word."phraseId"
+		FROM phrase_word
+		WHERE phrase_word."wordId" = "Gloss"."wordId" AND "Gloss"."languageId" = lang_id
+	),
+	footnote_update AS (
+		UPDATE "Footnote"
+		SET "phraseId" = phrase_word."phraseId"
+		FROM phrase_word
+		WHERE phrase_word."wordId" = "Footnote"."wordId" AND "Footnote"."languageId" = lang_id
+	)
+	UPDATE "TranslatorNote"
+	SET "phraseId" = phrase_word."phraseId"
+	FROM phrase_word
+	WHERE phrase_word."wordId" = "TranslatorNote"."wordId" AND "TranslatorNote"."languageId" = lang_id;
+
+	raise notice 'Done';
+END $$;


### PR DESCRIPTION
<!--
  Thank you for your PR! Please follow this template to help us review your PR quickly.
-->

## What has changed

* Added phrases to the database
* All writes (glosses and notes) that used to point to a word, now additionally point to a phrase
* A sql script to connect existing glosses and notes to a single word phrase

<!--
  Please name your PR following conventional commits.
  https://www.conventionalcommits.org/en/v1.0.0/
  The main ones to use are `feat`, `fix`, `chore`, `build`, `refactor`, and `docs`.

  If your PR is not connected to an issue, please describe the reason for your
  changes. Please also describe what you have changed. For more complex changes, include a self review that goes into more detail. Please also call attention to breaking changes, particularly in the shape of API routes.
-->

## Connected Issues

This is the first two steps of #376 as well as the migration script we can use for step three

<!--
  If this PR resolves an issue, please add `closes #issue-no` below to connect the issue to the PR.
-->

## QA Steps

1. Run `nx run db:prisma migrate dev`
2. Create a gloss or a note
3. Look in the database to see that a phrase and phrase word have been created and connected to the gloss and phrase.
4. No existing user facing behavior should chnage

<!-- Please describe how to test what you've changed. -->

## Post-Deployment

<!--
  Please describe any tasks that must be executed after this change is deployed.
-->

- [x] Nothing required
