### PR TITLE
refactor: process all queries through a phrase instead of a word ID

### DIFF
--- a/packages/api/pages/api/languages/[code]/verses/[verseId]/next-unapproved-verse.ts
+++ b/packages/api/pages/api/languages/[code]/verses/[verseId]/next-unapproved-verse.ts
@@ -23,13 +23,19 @@ export default createRoute<{ code: string; verseId: string }>()
       }
 
       const [result] = await client.$queryRaw<NextUnapprovedVerseResult>`
-        SELECT "Word"."verseId" as "nextUnapprovedVerseId"
-          FROM "Word" 
-          LEFT OUTER JOIN "Gloss" ON "Gloss"."wordId" = "Word"."id" 
-            AND "Gloss"."languageId" = ${language.id}::uuid
-        WHERE "Word"."verseId" > ${req.query.verseId} 
-          AND ("Gloss"."state" = 'UNAPPROVED' OR "Gloss"."state" IS NULL)
-        ORDER BY "Word"."id" LIMIT 1;
+        SELECT w."verseId" as "nextUnapprovedVerseId"
+        FROM "Word" AS w
+        LEFT JOIN LATERAL (
+          SELECT FROM "PhraseWord" AS phw
+          JOIN "Phrase" AS ph ON ph.id = phw."phraseId"
+            AND ph."languageId" = ${language.id}::uuid
+          LEFT JOIN "Gloss" AS g ON g."phraseId" = ph.id
+            AND (g."state" = 'UNAPPROVED' OR g."state" IS NULL)
+          WHERE phw."wordId" = w.id
+        ) AS g ON true
+        WHERE w."verseId" > ${req.query.verseId}
+        ORDER BY w."id"
+        LIMIT 1
       `;
 
       res.ok({ nextUnapprovedVerseId: result.nextUnapprovedVerseId });

--- a/packages/api/pages/api/languages/[code]/verses/[verseId]/next-unapproved-verse.ts
+++ b/packages/api/pages/api/languages/[code]/verses/[verseId]/next-unapproved-verse.ts
@@ -26,14 +26,14 @@ export default createRoute<{ code: string; verseId: string }>()
         SELECT w."verseId" as "nextUnapprovedVerseId"
         FROM "Word" AS w
         LEFT JOIN LATERAL (
-          SELECT FROM "PhraseWord" AS phw
+          SELECT g.state AS state FROM "PhraseWord" AS phw
           JOIN "Phrase" AS ph ON ph.id = phw."phraseId"
-            AND ph."languageId" = ${language.id}::uuid
           LEFT JOIN "Gloss" AS g ON g."phraseId" = ph.id
-            AND (g."state" = 'UNAPPROVED' OR g."state" IS NULL)
           WHERE phw."wordId" = w.id
+			      AND ph."languageId" = ${language.id}::uuid
         ) AS g ON true
         WHERE w."verseId" > ${req.query.verseId}
+          AND (g."state" = 'UNAPPROVED' OR g."state" IS NULL)
         ORDER BY w."id"
         LIMIT 1
       `;

--- a/packages/api/pages/api/languages/[code]/words/[wordId]/gloss.ts
+++ b/packages/api/pages/api/languages/[code]/words/[wordId]/gloss.ts
@@ -36,7 +36,6 @@ export default createRoute<{ code: string; wordId: string }>()
       const fields: {
         gloss?: string;
         state?: PrismaTypes.GlossState;
-        phraseId?: number;
       } = {};
 
       if (typeof req.body.state !== 'undefined') {
@@ -78,7 +77,6 @@ export default createRoute<{ code: string; wordId: string }>()
             },
           });
         }
-        fields.phraseId = phrase.id;
 
         const originalGloss = await tx.gloss.findUnique({
           where: {
@@ -98,6 +96,7 @@ export default createRoute<{ code: string; wordId: string }>()
           update: fields,
           create: {
             ...fields,
+            phraseId: phrase.id,
             wordId: req.query.wordId,
             languageId: language.id,
           },

--- a/packages/db/src/migrations/20240426220411_phrases_required/migration.sql
+++ b/packages/db/src/migrations/20240426220411_phrases_required/migration.sql
@@ -1,0 +1,64 @@
+/*
+  Warnings:
+
+  - The primary key for the `Footnote` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `Gloss` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `TranslatorNote` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - A unique constraint covering the columns `[wordId,languageId]` on the table `Footnote` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[wordId,languageId]` on the table `Gloss` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[wordId,languageId]` on the table `TranslatorNote` will be added. If there are existing duplicate values, this will fail.
+  - Made the column `phraseId` on table `Footnote` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `phraseId` on table `Gloss` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `phraseId` on table `TranslatorNote` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Footnote" DROP CONSTRAINT "Footnote_phraseId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Gloss" DROP CONSTRAINT "Gloss_phraseId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "TranslatorNote" DROP CONSTRAINT "TranslatorNote_phraseId_fkey";
+
+-- DropIndex
+DROP INDEX "Footnote_phraseId_key";
+
+-- DropIndex
+DROP INDEX "Gloss_phraseId_key";
+
+-- DropIndex
+DROP INDEX "TranslatorNote_phraseId_key";
+
+-- AlterTable
+ALTER TABLE "Footnote" DROP CONSTRAINT "Footnote_pkey",
+ALTER COLUMN "phraseId" SET NOT NULL,
+ADD CONSTRAINT "Footnote_pkey" PRIMARY KEY ("phraseId");
+
+-- AlterTable
+ALTER TABLE "Gloss" DROP CONSTRAINT "Gloss_pkey",
+ALTER COLUMN "phraseId" SET NOT NULL,
+ADD CONSTRAINT "Gloss_pkey" PRIMARY KEY ("phraseId");
+
+-- AlterTable
+ALTER TABLE "TranslatorNote" DROP CONSTRAINT "TranslatorNote_pkey",
+ALTER COLUMN "phraseId" SET NOT NULL,
+ADD CONSTRAINT "TranslatorNote_pkey" PRIMARY KEY ("phraseId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Footnote_wordId_languageId_key" ON "Footnote"("wordId", "languageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Gloss_wordId_languageId_key" ON "Gloss"("wordId", "languageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TranslatorNote_wordId_languageId_key" ON "TranslatorNote"("wordId", "languageId");
+
+-- AddForeignKey
+ALTER TABLE "Gloss" ADD CONSTRAINT "Gloss_phraseId_fkey" FOREIGN KEY ("phraseId") REFERENCES "Phrase"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TranslatorNote" ADD CONSTRAINT "TranslatorNote_phraseId_fkey" FOREIGN KEY ("phraseId") REFERENCES "Phrase"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Footnote" ADD CONSTRAINT "Footnote_phraseId_fkey" FOREIGN KEY ("phraseId") REFERENCES "Phrase"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/src/schema.prisma
+++ b/packages/db/src/schema.prisma
@@ -228,22 +228,26 @@ model Language {
   textDirection       TextDirection        @default(ltr)
   /// The list of Bible translation IDs associated with this language.
   bibleTranslationIds String[]
-  /// The list of glosses of different words for this language.
-  glosses             Gloss[]
   // The gloss history for this language.
   glossHistory        GlossHistoryEntry[]
   /// The list of machine glosses of different words for this language.
   machineGlosses      MachineGloss[]
-  // The list of translator notes of different words for this language.
-  translatorNotes     TranslatorNote[]
-  // The list of footnotes of different words for this language.
-  footnotes           Footnote[]
   /// The list of roles for members of this language.
   roles               LanguageMemberRole[]
   /// The pending import job if any.
   importJob           LanguageImportJob?
   /// The phrases in this language.
   phrases             Phrase[]
+
+  /// The list of translator notes of different words for this language.
+  /// @deprecated
+  translatorNotes TranslatorNote[]
+  /// The list of footnotes of different words for this language.
+  /// @deprecated
+  footnotes       Footnote[]
+  /// The list of glosses of different words for this language.
+  /// @deprecated
+  glosses         Gloss[]
 }
 
 /// Keeps track of a language import job.
@@ -325,24 +329,29 @@ enum GlossState {
 
 /// A gloss of a word in a particular language.
 model Gloss {
+  /// The phrase the gloss applies to.
+  phrase   Phrase     @relation(fields: [phraseId], references: [id])
+  /// The ID of phrase the gloss applies to.
+  phraseId Int        @id
+  /// The text of the gloss.
+  gloss    String?
+  /// The approval state of the gloss.
+  state    GlossState @default(UNAPPROVED)
+
   /// The word being glossed.
-  word       Word       @relation(fields: [wordId], references: [id])
+  /// @deprecated
+  word       Word     @relation(fields: [wordId], references: [id])
   /// The ID of the word being glossed.
+  /// @deprecated
   wordId     String
   /// The language of the gloss.
-  language   Language   @relation(fields: [languageId], references: [id])
+  /// @deprecated
+  language   Language @relation(fields: [languageId], references: [id])
   /// The ID of the language of the gloss.
-  languageId String     @db.Uuid
-  /// The text of the gloss.
-  gloss      String?
-  /// The approval state of the gloss.
-  state      GlossState @default(UNAPPROVED)
-  /// The phrase the gloss applies to.
-  phrase     Phrase?    @relation(fields: [phraseId], references: [id])
-  /// The ID of phrase the gloss applies to.
-  phraseId   Int?       @unique
+  /// @deprecated
+  languageId String   @db.Uuid
 
-  @@id([wordId, languageId])
+  @@unique([wordId, languageId])
 }
 
 /// Represents a gloss update for a particular language.
@@ -415,52 +424,62 @@ enum ResourceCode {
 
 /// The translator note for a word in a particular language.
 model TranslatorNote {
+  /// The phrase the note applies to.
+  phrase    Phrase   @relation(fields: [phraseId], references: [id])
+  /// The ID of phrase the note applies to.
+  phraseId  Int      @id
+  /// The author of the most recent update to the note.
+  author    User     @relation(fields: [authorId], references: [id])
+  /// The ID of the author of the most recent update to the note.
+  authorId  String   @db.Uuid
+  /// The timestamp of the last update.
+  timestamp DateTime
+  /// The content of the note.
+  content   String
+
   /// The word being noted.
+  /// @deprecated
   word       Word     @relation(fields: [wordId], references: [id])
   /// The ID of the word being noted.
+  /// @deprecated
   wordId     String
   /// The language that the note applies to.
+  /// @deprecated
   language   Language @relation(fields: [languageId], references: [id])
   /// The ID of the language that the note applies to.
+  /// @deprecated
   languageId String   @db.Uuid
-  /// The author of the most recent update to the note.
-  author     User     @relation(fields: [authorId], references: [id])
-  /// The ID of the author of the most recent update to the note.
-  authorId   String   @db.Uuid
-  /// The timestamp of the last update.
-  timestamp  DateTime
-  /// The content of the note.
-  content    String
-  /// The phrase the note applies to.
-  phrase     Phrase?  @relation(fields: [phraseId], references: [id])
-  /// The ID of phrase the note applies to.
-  phraseId   Int?     @unique
 
-  @@id([wordId, languageId])
+  @@unique([wordId, languageId])
 }
 
 /// The footnote for a word in a particular language.
 model Footnote {
+  /// The phrase the note applies to.
+  phrase    Phrase   @relation(fields: [phraseId], references: [id])
+  /// The ID of phrase the note applies to.
+  phraseId  Int      @id
+  /// The author of the most recent update to the note.
+  author    User     @relation(fields: [authorId], references: [id])
+  /// The ID of the author of the most recent update to the note.
+  authorId  String   @db.Uuid
+  /// The timestamp of the last update.
+  timestamp DateTime
+  /// The content of the note.
+  content   String
+
   /// The word being noted.
+  /// @deprecated
   word       Word     @relation(fields: [wordId], references: [id])
   /// The ID of the word being noted.
+  /// @deprecated
   wordId     String
   /// The language that the note applies to.
+  /// @deprecated
   language   Language @relation(fields: [languageId], references: [id])
   /// The ID of the language that the note applies to.
+  /// @deprecated
   languageId String   @db.Uuid
-  /// The author of the most recent update to the note.
-  author     User     @relation(fields: [authorId], references: [id])
-  /// The ID of the author of the most recent update to the note.
-  authorId   String   @db.Uuid
-  /// The timestamp of the last update.
-  timestamp  DateTime
-  /// The content of the note.
-  content    String
-  /// The phrase the note applies to.
-  phrase     Phrase?  @relation(fields: [phraseId], references: [id])
-  /// The ID of phrase the note applies to.
-  phraseId   Int?     @unique
 
-  @@id([wordId, languageId])
+  @@unique([wordId, languageId])
 }

--- a/packages/lambda-functions/functions/import-language/index.ts
+++ b/packages/lambda-functions/functions/import-language/index.ts
@@ -111,31 +111,6 @@ export const lambdaHandler = async (event: SQSEvent) => {
             })),
           });
 
-          const phrases = await client.$queryRaw<{ id: number }[]>`
-            INSERT INTO "Phrase" ("languageId")
-            SELECT ${language.id}::uuid FROM generate_series(1,${glossData.length})
-            RETURNING id
-          `;
-          for (const i in glossData) {
-            glossData[i].phraseId = phrases[i].id;
-          }
-
-          await client.phraseWord.createMany({
-            data: glossData.map((word) => ({
-              wordId: word.wordId,
-              phraseId: word.phraseId,
-            })),
-          });
-
-          await client.gloss.createMany({
-            data: glossData.map((word) => ({
-              wordId: word.wordId,
-              languageId: language.id,
-              gloss: word.gloss,
-              phraseId: word.phraseId,
-            })),
-          });
-
           const job = await client.languageImportJob.findUnique({
             where: { languageId: language.id },
           });


### PR DESCRIPTION
<!--
  Thank you for your PR! Please follow this template to help us review your PR quickly.
-->

## What has changed

**This PR assumes that phrases have been created and phrase IDs set on all glosses and notes in production for all languages.**

* Updates API queries to use the phrase to load glosses and notes
* Updates the DB schema to make the phrase ID the primary key for glosses and notes.
* The language and word ID are still required on the gloss and notes tables for now

<!--
  Please name your PR following conventional commits.
  https://www.conventionalcommits.org/en/v1.0.0/
  The main ones to use are `feat`, `fix`, `chore`, `build`, `refactor`, and `docs`.

  If your PR is not connected to an issue, please describe the reason for your
  changes. Please also describe what you have changed. For more complex changes, include a self review that goes into more detail. Please also call attention to breaking changes, particularly in the shape of API routes.
-->

## Connected Issues

next steps in #376 

<!--
  If this PR resolves an issue, please add `closes #issue-no` below to connect the issue to the PR.
-->

## QA Steps

* Run `nx run db:prisma migrate dev`
* Navigate through a few verses and confirm that translation line load correctly
* Check that notes load
* Check that suggestions load
* Check that next unapproved verse works

<!-- Please describe how to test what you've changed. -->

## Post-Deployment

<!--
  Please describe any tasks that must be executed after this change is deployed.
-->

- [x] Nothing required
