### PR TITLE
fix: blurring notes editor leads to loss of data

### DIFF
--- a/packages/web/src/features/translation/TranslationSidebar.tsx
+++ b/packages/web/src/features/translation/TranslationSidebar.tsx
@@ -270,13 +270,8 @@ export const TranslationSidebar = ({
                         key={`translatorNote--${word.id}`}
                         name="translatorNoteContent"
                         value={translatorNoteContent}
-                        onBlur={async (e) => {
-                          saveTranslatorNote(e.target.value);
-                          saveTranslatorNote.flush();
-                        }}
-                        onChange={async (e) => {
-                          saveTranslatorNote(e.target.value);
-                        }}
+                        onBlur={() => saveTranslatorNote.flush()}
+                        onChange={saveTranslatorNote}
                       />
                     ) : (
                       <RichText content={translatorNoteContent} />
@@ -300,13 +295,8 @@ export const TranslationSidebar = ({
                       key={`footnote--${word.id}`}
                       name="footnoteContent"
                       value={footnoteContent}
-                      onBlur={async (e) => {
-                        saveFootnote(e.target.value);
-                        saveFootnote.flush();
-                      }}
-                      onChange={async (e) => {
-                        saveFootnote(e.target.value);
-                      }}
+                      onBlur={() => saveFootnote.flush()}
+                      onChange={saveFootnote}
                     />
                   ) : (
                     <RichText content={footnoteContent} />

--- a/packages/web/src/shared/components/form/RichTextInput.tsx
+++ b/packages/web/src/shared/components/form/RichTextInput.tsx
@@ -1,16 +1,15 @@
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { Icon } from '../Icon';
-import { ComponentProps, forwardRef, useEffect, useRef } from 'react';
+import { ComponentProps, forwardRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChangeHandler } from 'react-hook-form';
 
 export interface RichTextInputProps {
   name: string;
   value?: string;
   defaultValue?: string;
-  onChange?: ChangeHandler;
-  onBlur?: ChangeHandler;
+  onChange?: (newValue: string) => void;
+  onBlur?: () => void;
   'aria-labelledby'?: string;
   'aria-label'?: string;
 }
@@ -32,7 +31,6 @@ export const extensions = [
 const RichTextInput = forwardRef<RichTextInputRef, RichTextInputProps>(
   ({ name, onChange, onBlur, value, defaultValue, ...props }, ref) => {
     const { t } = useTranslation(['common']);
-    const hiddenInput = useRef<HTMLInputElement>(null);
 
     const editor = useEditor({
       extensions,
@@ -43,37 +41,18 @@ const RichTextInput = forwardRef<RichTextInputRef, RichTextInputProps>(
         },
       },
       content: value ?? defaultValue,
-      onCreate({ editor }) {
-        const input = hiddenInput.current;
-        if (input) {
-          input.value = editor.getHTML();
-        }
-      },
-      onUpdate({ editor }) {
-        const input = hiddenInput.current;
-        if (input) {
-          const value = editor.getHTML();
-          input.value = value;
-          onChange?.({ target: input });
-        }
-      },
-      onBlur() {
-        const input = hiddenInput.current;
-        if (input) {
-          onBlur?.({ target: input });
-        }
-      },
+      onUpdate: ({ editor }) => onChange?.(editor?.getHTML()),
+      onBlur,
     });
 
     useEffect(() => {
-      editor?.commands.setContent(value ?? '', true, {
+      editor?.commands.setContent(value ?? '', false, {
         preserveWhitespace: 'full',
       });
     }, [value, editor]);
 
     return (
       <div className="border rounded border-gray-400 has-[:focus-visible]:outline outline-2 outline-green-300 bg-white">
-        <input type="hidden" ref={hiddenInput} name={name} />
         <div className="border-gray-400 border-b p-1 flex gap-3">
           <div className="flex gap-1">
             <RichTextInputButton

--- a/packages/web/src/shared/components/form/RichTextInput.tsx
+++ b/packages/web/src/shared/components/form/RichTextInput.tsx
@@ -66,7 +66,7 @@ const RichTextInput = forwardRef<RichTextInputRef, RichTextInputProps>(
     });
 
     useEffect(() => {
-      editor?.commands.setContent(value ?? '', false, {
+      editor?.commands.setContent(value ?? '', true, {
         preserveWhitespace: 'full',
       });
     }, [value, editor]);


### PR DESCRIPTION
<!--
  Thank you for your PR! Please follow this template to help us review your PR quickly.
-->

## What has changed
- The bug was caused by the fact that the `value` in the hidden input of the `RichTextInput` was not updated when the `value` prop changed. So, when the user switched words, the hidden input of the notes editor was not updated and `saveTranslatorNote` would save the notes of the previous word to the database.
-  Now, changing the `value` prop of the `RichTextInput` emits an update. This updates the value in the hidden input. 

## Connected Issues

closes #392
<!--
  If this PR resolves an issue, please add `closes #issue-no` below to connect the issue to the PR.
-->

## QA Steps

<!-- Please describe how to test what you've changed. -->

1. Find two words with translator notes (or footnotes)
2. Open the notes tab for the first word. Focus on translator notes editor and observe its content.
3. Open the notes tab for second word. Focus on translator notes editor and observe its content.
4. Blur. Reload the page.
5. Confirm that the notes of the first and second words have not changed.

## Post-Deployment

<!--
  Please describe any tasks that must be executed after this change is deployed.
-->

- [ ] Nothing required
