### PR TITLE
fix: note phrases join

### DIFF
--- a/packages/api/pages/api/languages/[code]/verses/[verseId]/notes.ts
+++ b/packages/api/pages/api/languages/[code]/verses/[verseId]/notes.ts
@@ -35,9 +35,12 @@ export default createRoute<{ code: string; verseId: string }>()
           COALESCE(fn."content", '') AS "footnoteContent"
         FROM "Word" AS w
 
-        LEFT JOIN "PhraseWord" AS phw ON phw."wordId" = w.id
-        LEFT JOIN "Phrase" AS ph ON ph.id = phw."phraseId"
-          AND ph."languageId" = ${language.id}::uuid
+        LEFT JOIN LATERAL (
+          SELECT phw."wordId", ph.id FROM "PhraseWord" AS phw
+          JOIN "Phrase" AS ph ON ph.id = phw."phraseId"
+          WHERE phw."wordId" = w.id
+            AND ph."languageId" = ${language.id}::uuid
+        ) AS ph ON true
 
         LEFT JOIN "TranslatorNote" tn ON tn."phraseId" = ph.id
         LEFT JOIN "User" AS tn_u ON tn_u.id = tn."authorId"

--- a/packages/api/pages/api/languages/[code]/verses/[verseId]/notes.ts
+++ b/packages/api/pages/api/languages/[code]/verses/[verseId]/notes.ts
@@ -36,7 +36,7 @@ export default createRoute<{ code: string; verseId: string }>()
         FROM "Word" AS w
 
         LEFT JOIN LATERAL (
-          SELECT phw."wordId", ph.id FROM "PhraseWord" AS phw
+          SELECT ph.id FROM "PhraseWord" AS phw
           JOIN "Phrase" AS ph ON ph.id = phw."phraseId"
           WHERE phw."wordId" = w.id
             AND ph."languageId" = ${language.id}::uuid


### PR DESCRIPTION
<!--
  Thank you for your PR! Please follow this template to help us review your PR quickly.
-->

## What has changed
The raw database query in `notes.ts` has been fixed. Now, it uses a `LEFT JOIN LATERL SELECT` to join the words and phrases.

## Connected Issues

closes #398

## QA Steps

1. Test the query in pgAdmin or add a `console.log` in `notes.ts`. Observe if there are any duplicates in the results.

## Post-Deployment

<!--
  Please describe any tasks that must be executed after this change is deployed.
-->

- [x] Nothing required
